### PR TITLE
Add filter by zoom level option

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -78,8 +78,8 @@ exports.getReports = functions.https.onRequest((req, res) => {
             const locationData = data["location"];
             if(locationData!==undefined)
             {
-              let dataLatitude = data["location"]["_latitude"];
-              let dataLongitude = data["location"]["_longitude"];
+              let dataLatitude = locationData["_latitude"];
+              let dataLongitude = locationData["_longitude"];
               if(dataLatitude!==undefined && dataLongitude!==undefined)
               {
                 const to = turf.point([dataLatitude, dataLongitude]);

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,4 +1,3 @@
-
 const functions = require('firebase-functions');
 const cors = require('cors')({ origin: true });
 const admin = require('firebase-admin');
@@ -71,6 +70,8 @@ buildQuery = (queryParams, collection) => {
     let longBound = (distance/radius/Math.cos(latitude*(Math.PI/180)));
     let maxLongitude = longitude + longBound;
     let minLongitude = longitude - longBound;
+    geolib.computeDestinationPoint()
+    geolib.computeDestinationPoint({lat: 51.3, lng: 7.45}, 5000, 180)
 
     let lesserGeoPoint = new GeoPoint(minLatitude,minLongitude);
     let greaterGeoPoint = new GeoPoint(maxLatitude,maxLongitude);
@@ -87,14 +88,14 @@ exports.getReports = functions.https.onRequest((req, res) => {
         message: `Not Allowed`
       });
     }
-    let reports = database.collection('reports')
+    let reports = database.collection('reports');
     return buildQuery(req.query, reports)
       .get()
       .then(snapshot => {
         if (snapshot.empty) {
           res.status(200).send('No data!');
         } else {
-          let items = [];
+          let items = []
           snapshot.forEach(doc => {
             items.push({id: doc.id, data: doc.data()});
           });

--- a/functions/index.js
+++ b/functions/index.js
@@ -70,8 +70,6 @@ buildQuery = (queryParams, collection) => {
     let longBound = (distance/radius/Math.cos(latitude*(Math.PI/180)));
     let maxLongitude = longitude + longBound;
     let minLongitude = longitude - longBound;
-    geolib.computeDestinationPoint()
-    geolib.computeDestinationPoint({lat: 51.3, lng: 7.45}, 5000, 180)
 
     let lesserGeoPoint = new GeoPoint(minLatitude,minLongitude);
     let greaterGeoPoint = new GeoPoint(maxLatitude,maxLongitude);

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,10 +10,12 @@
     "logs": "firebase functions:log"
   },
   "dependencies": {
+    "@turf/turf": "^5.1.6",
     "cors": "^2.8.5",
     "firebase-admin": "~7.0.0",
-    "firebase-functions": "^2.2.0",
-    "moment": "^2.24.0"
+    "firebase-functions": "^2.2.1",
+    "moment": "^2.24.0",
+    "turf-point": "^2.0.1"
   },
   "devDependencies": {
     "eslint": "^5.12.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "cors": "^2.8.5",
     "dotenv": "^6.2.0",
     "firebase": "^5.8.3",
+    "geolib": "^2.0.24",
     "mapbox-gl": "^0.53.0",
     "material-ui-icons": "^1.0.0-beta.36",
     "react": "^16.8.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "cors": "^2.8.5",
     "dotenv": "^6.2.0",
     "firebase": "^5.8.3",
-    "geolib": "^2.0.24",
     "mapbox-gl": "^0.53.0",
     "material-ui-icons": "^1.0.0-beta.36",
     "react": "^16.8.2",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "dependencies": {
     "@material-ui/core": "^3.9.2",
     "@material-ui/icons": "^3.0.2",
+    "@turf/points-within-polygon": "^5.1.5",
+    "@turf/turf": "^5.1.6",
     "cors": "^2.8.5",
     "dotenv": "^6.2.0",
     "firebase": "^5.8.3",
+    "geofirestore": "^3.2.2",
     "mapbox-gl": "^0.53.0",
     "material-ui-icons": "^1.0.0-beta.36",
     "react": "^16.8.2",


### PR DESCRIPTION
This PR updates the 'getReports' function to handle location based querying. Turf library is used to compute the distance between the location of interest and locations fields in db. All locations that are in 1 mile distance to the location given in get request will be fetched. We can update the distance limit based on user input later; for now, I have used a 1 mile radius as the max limit.

Testing:
Firebase serve and pinging the end point by location. Example:
http://localhost:5000/seattlecarnivores-edca2/us-central1/getReports?location=53.29012,36.59229