### PR TITLE
Add filter by zoom level option 

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -2,6 +2,7 @@ const functions = require('firebase-functions');
 const cors = require('cors')({ origin: true });
 const admin = require('firebase-admin');
 const moment = require('moment');
+const turf = require('@turf/turf');
 admin.initializeApp(functions.config().firebase);
 const database = admin.firestore();
 
@@ -64,15 +65,41 @@ exports.getReports = functions.https.onRequest((req, res) => {
     return buildQuery(req.query, reports)
       .get()
       .then(snapshot => {
+        let items = []
         if (snapshot.empty) {
           res.status(200).send('No data!');
-        } else {
-          let items = []
+        } else if(req.query.location !== undefined) {
+          const [latitudeStr,longitudeStr] = req.query.location.split(",");
+          const queryLatitude = +latitudeStr;
+          const queryLongitude = +longitudeStr;
+          const from = turf.point([queryLatitude, queryLongitude]);
+          const options = {units: 'miles'};
+          snapshot.forEach(doc => {
+            const data = doc.data();
+            const locationData = data["location"];
+            if(locationData!==undefined)
+            {
+              let dataLatitude = locationData["_latitude"];
+              let dataLongitude = locationData["_longitude"];
+              if(dataLatitude!==undefined && dataLongitude!==undefined)
+              {
+                const to = turf.point([dataLatitude, dataLongitude]);
+                const distance = turf.distance(from, to, options);
+                // If distance is within 1 mile from the query lat long
+                if(distance<=1)
+                {
+                  items.push({id: doc.id, data: doc.data()});
+                }
+              }
+            }
+          });
+        }
+        else {
           snapshot.forEach(doc => {
             items.push({id: doc.id, data: doc.data()});
           });
-          res.status(200).send(items);
         }
+        items.length===0 ? res.status(200).send('No data!'): res.status(200).send(items);
       })
       .catch(err => {
         res.status(500).send(`Error getting documents: ${err}`);

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,10 +10,12 @@
     "logs": "firebase functions:log"
   },
   "dependencies": {
+    "@turf/turf": "^5.1.6",
     "cors": "^2.8.5",
     "firebase-admin": "~7.0.0",
     "firebase-functions": "^2.2.0",
-    "moment": "^2.24.0"
+    "moment": "^2.24.0",
+    "turf-point": "^2.0.1"
   },
   "devDependencies": {
     "eslint": "^5.12.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^3.9.2",
     "@material-ui/icons": "^3.0.2",
+    "@turf/turf": "^5.1.6",
     "cors": "^2.8.5",
     "dotenv": "^6.2.0",
     "firebase": "^5.8.3",


### PR DESCRIPTION

This PR updates the 'getReports' function to handle location based querying. Turf library is used to compute the distance between the location of interest and locations fields in db. All locations that are in 1 mile distance to the location given in get request will be fetched. We can update the distance limit based on user input later; for now, I have used a 1 mile radius as the max limit.

Testing:
Firebase serve and pinging the end point by location. Example:
http://localhost:5000/seattlecarnivores-edca2/us-central1/getReports?location=53.29012,36.59229