### PR TITLE
List view

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -76,10 +76,11 @@ Footer Styles
 
 .footerIconDiv {
     width: 100%;
-    position: absolute;
+    position: sticky;
     bottom: 0;
     left: 0;
-    margin-bottom: 25px;
+    padding-bottom: 25px;
+    background-color: white;
 }
 
 .footerIcons span {
@@ -90,4 +91,10 @@ Footer Styles
     text-transform: capitalize;
     margin: 0;
     color: gray;
+}
+
+.App {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
 }

--- a/src/components/ListCard.js
+++ b/src/components/ListCard.js
@@ -40,7 +40,7 @@ const styles = theme => ({
  * Get a string for a timestamp in the format that Cloud Firestore sends us.
  * Time should be an object with _nanoseconds and _seconds as fields.
  */
-const timeToString = (time) => {
+const timeToString = time => {
   const nanosInMillis = time._nanoseconds / 1000000;
   const secondsInMillis = time._seconds * 1000;
   return new Date(nanosInMillis + secondsInMillis).toLocaleString();
@@ -53,7 +53,7 @@ const timeToString = (time) => {
  * TODO: once we handle neighborhoods properly, we should return a string representing
  * the neighborhood here.
  */
-const locationToString = (location) => {
+const locationToString = location => {
   if (!location) {
     return "No location provided";
   }
@@ -63,7 +63,7 @@ const locationToString = (location) => {
   return location.toString();
 }
 
-const ListCard = (props) => {
+const ListCard = props => {
   const { classes, data } = props;
   return <Card className={classes.card}>
     <CardContent className={classes.allContent}>

--- a/src/components/ListCard.js
+++ b/src/components/ListCard.js
@@ -11,9 +11,7 @@ const DEFAULT_IMAGE_URL = "https://upload.wikimedia.org/wikipedia/commons/thumb/
 const styles = theme => ({
   picture: {
     width: 150,
-    height: 150,
-    minWidth: 150,
-    minHeight: 150
+    height: 150
   },
   info: {
     flexDirection: 'column',

--- a/src/components/ListCard.js
+++ b/src/components/ListCard.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import CardMedia from '@material-ui/core/CardMedia';
+import Typography from '@material-ui/core/Typography';
+import { withStyles } from '@material-ui/core/styles';
+
+// TODO find something better
+const DEFAULT_IMAGE_URL = "https://upload.wikimedia.org/wikipedia/commons/thumb/7/79/2010-brown-bear.jpg/200px-2010-brown-bear.jpg";
+
+const styles = theme => ({
+  picture: {
+    width: 150,
+    height: 150,
+    minWidth: 150,
+    minHeight: 150
+  },
+  info: {
+    flexDirection: 'column',
+    flexGrow: 1,
+    flex: 1,
+    textAlign: 'left'
+  },
+  card: {
+    marginBottom: 16,
+    marginLeft: 16,
+    marginRight: 16,
+    marginTop: 16,
+    height: 150,
+    maxWidth: 500,
+    minWidth: 500
+  },
+  allContent: {
+    display: 'flex',
+    padding: 0
+  }
+});
+
+/**
+ * Get a string for a timestamp in the format that Cloud Firestore sends us.
+ * Time should be an object with _nanoseconds and _seconds as fields.
+ */
+const timeToString = (time) => {
+  const nanosInMillis = time._nanoseconds / 1000000;
+  const secondsInMillis = time._seconds * 1000;
+  return new Date(nanosInMillis + secondsInMillis).toLocaleString();
+}
+
+/**
+ * Get a string representing a timestamp in the format that Cloud Firestore sends us.
+ * Should be something we can call toString on, falsy, or an object with _longitude and
+ * _latitude as fields.
+ * TODO: once we handle neighborhoods properly, we should return a string representing
+ * the neighborhood here.
+ */
+const locationToString = (location) => {
+  if (!location) {
+    return "No location provided";
+  }
+  if (location._longitude && location._latitude) {
+    return `${location._longitude} ${location._longitude}`;
+  }
+  return location.toString();
+}
+
+const ListCard = (props) => {
+  const { classes, data } = props;
+  return <Card className={classes.card}>
+    <CardContent className={classes.allContent}>
+      <CardMedia className={classes.picture}
+        image={data.image_url ? data.image_url : DEFAULT_IMAGE_URL}
+      />
+      <CardContent className={classes.info}>
+        <Typography variant={'h3'}>{data.species.toUpperCase()}</Typography>
+        <Typography variant={'subtitle1'}>{timeToString(data.time_seen ? data.time_seen : data.time_submitted)}</Typography>
+        <Typography variant={'subtitle1'}>{locationToString(data.location)}</Typography>
+      </CardContent>
+    </CardContent>
+  </Card>
+};
+
+export default withStyles(styles)(ListCard);

--- a/src/components/ListCard.js
+++ b/src/components/ListCard.js
@@ -72,7 +72,7 @@ const ListCard = (props) => {
       />
       <CardContent className={classes.info}>
         <Typography variant={'h3'}>{data.species.toUpperCase()}</Typography>
-        <Typography variant={'subtitle1'}>{timeToString(data.time_seen ? data.time_seen : data.time_submitted)}</Typography>
+        <Typography variant={'subtitle1'}>{timeToString(data.time_seen)}</Typography>
         <Typography variant={'subtitle1'}>{locationToString(data.location)}</Typography>
       </CardContent>
     </CardContent>

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import ListCard from '../components/ListCard';
+import { withStyles } from '@material-ui/core/styles';
+
+const styles = theme => ({
+  container: {
+    backgroundColor: 'grey',
+    display: 'flex',
+    alignItems: 'center',
+    flexDirection: 'column'
+  }
+});
+
+class ListView extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {reports: []}
+  }
+
+  componentDidMount() {
+    fetch(process.env.REACT_APP_GET_REPORTS, {method: 'GET', headers: {'Content-Length': 0}})
+      .then(response => response.json())
+      .then(reports => {
+        this.setState({...this.state, reports})
+      })
+      .catch(error => error);
+  }
+
+  render() {
+    return (
+    <div className={this.props.classes.container}>
+    {
+      this.state.reports
+      ? this.state.reports.map((report) => <ListCard data={report.data} key={report.id}/>)
+      : 'Loading...'
+    }
+    </div>
+  )}
+}
+
+export default withStyles(styles)(ListView);

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -12,10 +12,8 @@ const styles = theme => ({
 });
 
 class ListView extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {reports: []}
-  }
+
+  state = {reports: []};
 
   componentDidMount() {
     fetch(process.env.REACT_APP_GET_REPORTS, {method: 'GET', headers: {'Content-Length': 0}})
@@ -27,11 +25,13 @@ class ListView extends React.Component {
   }
 
   render() {
+    const {reports} = this.state;
+    const {classes} = this.props;
     return (
-    <div className={this.props.classes.container}>
+    <div className={classes.container}>
     {
-      this.state.reports
-      ? this.state.reports.map((report) => <ListCard data={report.data} key={report.id}/>)
+      reports
+      ? reports.map((report) => <ListCard data={report.data} key={report.id}/>)
       : 'Loading...'
     }
     </div>

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -1,25 +1,26 @@
 import React from 'react';
 import ListCard from '../components/ListCard';
 import { withStyles } from '@material-ui/core/styles';
+import axios from 'axios';
+import CircularProgress from '@material-ui/core/CircularProgress';
 
 const styles = theme => ({
   container: {
     backgroundColor: 'grey',
     display: 'flex',
     alignItems: 'center',
-    flexDirection: 'column'
+    flexDirection: 'column',
   }
 });
 
 class ListView extends React.Component {
 
-  state = {reports: []};
+  state = {reports: null};
 
   componentDidMount() {
-    fetch(process.env.REACT_APP_GET_REPORTS, {method: 'GET', headers: {'Content-Length': 0}})
-      .then(response => response.json())
+    axios.get(process.env.REACT_APP_GET_REPORTS)
       .then(reports => {
-        this.setState({...this.state, reports})
+        this.setState({...this.state, reports: reports.data});
       })
       .catch(error => error);
   }
@@ -32,7 +33,7 @@ class ListView extends React.Component {
     {
       reports
       ? reports.map((report) => <ListCard data={report.data} key={report.id}/>)
-      : 'Loading...'
+      : <CircularProgress className={classes.progress}/>
     }
     </div>
   )}

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -10,6 +10,8 @@ const styles = theme => ({
     display: 'flex',
     alignItems: 'center',
     flexDirection: 'column',
+    height: '100%',
+    justifyContent: 'center'
   }
 });
 

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -1,12 +1,12 @@
-import React from 'react';
-import ListCard from '../components/ListCard';
-import { withStyles } from '@material-ui/core/styles';
+import React, {Component} from 'react';
 import axios from 'axios';
+import { withStyles } from '@material-ui/core/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
+import ListCard from '../components/ListCard';
 
 const styles = theme => ({
   container: {
-    backgroundColor: 'grey',
+    backgroundColor: '#D3D3D3',
     display: 'flex',
     alignItems: 'center',
     flexDirection: 'column',
@@ -15,14 +15,16 @@ const styles = theme => ({
   }
 });
 
-class ListView extends React.Component {
+const getReports = 'https://us-central1-seattlecarnivores-edca2.cloudfunctions.net/getReports';
+
+class ListView extends Component {
 
   state = {reports: null};
 
   componentDidMount() {
-    axios.get(process.env.REACT_APP_GET_REPORTS)
+    axios.get(getReports)
       .then(reports => {
-        this.setState({...this.state, reports: reports.data});
+        this.setState({reports: reports.data});
       })
       .catch(error => error);
   }
@@ -30,13 +32,12 @@ class ListView extends React.Component {
   render() {
     const {reports} = this.state;
     const {classes} = this.props;
+    if (!reports) {
+      return <CircularProgress />;
+    }
     return (
     <div className={classes.container}>
-    {
-      reports
-      ? reports.map((report) => <ListCard data={report.data} key={report.id}/>)
-      : <CircularProgress className={classes.progress}/>
-    }
+      {reports.map((report) => <ListCard data={report.data} key={report.id}/>)}
     </div>
   )}
 }

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -2,12 +2,14 @@ import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 import Form from './Form';
 import Map from './Map';
+import ListView from './ListView';
 
 const Main = () => (
   <main>
     <Switch>
       <Route exact path="/" component={Map}/>
       <Route exact path="/reports/create" component={Form}/>
+      <Route exact path="/list" component={ListView}/>
     </Switch>
   </main>
 );

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -3,15 +3,23 @@ import { Switch, Route } from 'react-router-dom';
 import Form from './Form';
 import Map from './Map';
 import ListView from './ListView';
+import { withStyles } from '@material-ui/core/styles';
 
-const Main = () => (
-  <main>
+const styles = theme => ({
+  main: {
+    flexGrow: 1
+  }
+});
+
+const Main = (props) => {
+  const {classes} = props;
+  return <main className={classes.main}>
     <Switch>
       <Route exact path="/" component={Map}/>
       <Route exact path="/reports/create" component={Form}/>
       <Route exact path="/list" component={ListView}/>
     </Switch>
   </main>
-);
+}
 
-export default Main;
+export default withStyles(styles)(Main);

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -3,23 +3,15 @@ import { Switch, Route } from 'react-router-dom';
 import Form from './Form';
 import Map from './Map';
 import ListView from './ListView';
-import { withStyles } from '@material-ui/core/styles';
 
-const styles = theme => ({
-  main: {
-    flexGrow: 1
-  }
-});
-
-const Main = (props) => {
-  const {classes} = props;
-  return <main className={classes.main}>
+const Main = () => (
+  <main>
     <Switch>
       <Route exact path="/" component={Map}/>
       <Route exact path="/reports/create" component={Form}/>
       <Route exact path="/list" component={ListView}/>
     </Switch>
   </main>
-}
+);
 
-export default withStyles(styles)(Main);
+export default Main;


### PR DESCRIPTION
This PR adds the list view, which looks like this on desktop:
<img width="708" alt="image" src="https://user-images.githubusercontent.com/12106730/55646769-e5927a80-5790-11e9-8ebf-eae782852dd9.png">
... and this on mobile:
<img width="523" alt="image" src="https://user-images.githubusercontent.com/12106730/55646802-f3480000-5790-11e9-9533-fb964ad17175.png">

The ListCard expects the following fields to be present in the result we get from firebase:
 - location: {_latitude: , _longitude}
 - species: string
 - time_seen: timestamp (defaults to time_submitted if not provided) (should it default?)
 - image_url: url string (defaults to our default image, currently a bear stolen from wikipedia)

I also added a REACT_APP_GET_REPORTS field to my .env file pointing to a local instance of firebase functions. I'm not sure if that's the best way to go about it or if I don't even need to worry about using .env for that kind of thing. 

Things that need to be done before this is totally complete:
 - [ ] get a better (and local) default image
 - [ ] convert locations into neighborhoods
 - [ ] scrolling with the footer div
 - [ ] footer div background color?
 - [ ] actually deploy getReports to firebase (have to resolve a couple of linting issues)