### PR TITLE
Fix some CSS issues

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,13 +4,10 @@
     text-align: center;
     display: flex;
     flex-direction: column;
-    height: 100vh;
 }
 
 .Main {
-    background-color: lightgray;
-    /*padding-bottom: 120px;*/
-    height: 100vh;
+    min-height: 100vh;
     z-index: 99;
 }
 
@@ -216,8 +213,16 @@ input {
 List + Card
  */
 
+.backgroundCardContainer {
+    padding-top: 100px;
+    padding-bottom: 20px;
+    background-color: #ececec;
+}
+
 .cardContainer {
-    margin-bottom: 80px;
+    position: relative;
+    top: -100px;
+    margin-bottom: 16px;
     display: flex;
     align-items: center;
     flex-direction: column;
@@ -318,7 +323,8 @@ Footer Styles
     left: 0;
     padding: 25px 0;
     background-color: white;
-    position: fixed;
+    /* position: fixed; */
+    position: sticky;
     z-index: 101;
 
 }

--- a/src/components/DesktopHeader.js
+++ b/src/components/DesktopHeader.js
@@ -36,7 +36,7 @@ class DesktopHeader extends Component {
     const { classes, history } = this.props;
 
     return (
-      <div style={{ position: 'fixed', width: '100%', zIndex: 100 }}>
+      <div style={{ position: 'sticky', top: 0, width: '100%', zIndex: 100 }}>
         <AppBar position="static" className="appBar">
           <div className="logo"/>
           <h1 className="headerTitle" onClick={() => history.push('/')} style={{ cursor: 'pointer' }}>

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -28,9 +28,11 @@ class ListView extends Component {
       return <CircularProgress/>;
     }
     return (
-      <div className="cardContainer">
-        {reports.filter(report => dataMatchesFilter(report, filter))
-          .map((report) => <ListCard data={report.data} key={report.id}/>)}
+      <div className="backgroundCardContainer">
+        <div className="cardContainer">
+          {reports.filter(report => dataMatchesFilter(report, filter))
+            .map((report) => <ListCard data={report.data} key={report.id}/>)}
+        </div>
       </div>
     )
   }

--- a/src/components/MobileHeader.js
+++ b/src/components/MobileHeader.js
@@ -33,7 +33,7 @@ class MobileHeader extends Component {
     const { history, location, classes} = this.props;
 
     return (
-      <div style={{ position: 'fixed', width: '100%', zIndex: 100 }}>
+      <div style={{ position: 'sticky', top: 0, width: '100%', zIndex: 100 }}>
         <AppBar position="static" color="default">
           <div className="headerDiv">
             <div className="topHeader">


### PR DESCRIPTION
This PR addresses a couple of styling issues that I've noticed, namely the following: 

 - The list view background is too dark and doesn't extend all the way down the list on mobile or desktop, and it's appearing in the desktop form view when it shouldn't:
<img width="1117" alt="Screen Shot 2019-05-31 at 10 13 16 AM" src="https://user-images.githubusercontent.com/12106730/58722856-646cf380-838d-11e9-9763-92729c820ca9.png">
<img width="678" alt="Screen Shot 2019-05-31 at 10 13 41 AM" src="https://user-images.githubusercontent.com/12106730/58722901-85cddf80-838d-11e9-9b3e-2325cb66fa3f.png">
<img width="1469" alt="Screen Shot 2019-05-31 at 10 14 07 AM" src="https://user-images.githubusercontent.com/12106730/58722963-aa29bc00-838d-11e9-876b-75afebcf21c7.png">

 - The form view gets blocked by the header on desktop since the header is `position:absolute;` and takes up no DOM space:
<img width="1469" alt="Screen Shot 2019-05-31 at 10 14 03 AM" src="https://user-images.githubusercontent.com/12106730/58722919-92523800-838d-11e9-9717-8c795ea7eaa9.png">
 I've addressed these issues by making the headers and footers `position: sticky` instead of `position:absolute`, expanding the height of the `Main` div, and creating a special background div for the list view with a lighter background color. See the results:

 - Form view now has a white background as expected:
<img width="1469" alt="Screen Shot 2019-05-31 at 10 14 32 AM" src="https://user-images.githubusercontent.com/12106730/58723138-2fad6c00-838e-11e9-91ba-f7082d870f6c.png">

 - List view looks good when scrolled all the way to the top on desktop and mobile:
<img width="1469" alt="Screen Shot 2019-05-31 at 10 14 46 AM" src="https://user-images.githubusercontent.com/12106730/58723141-320fc600-838e-11e9-969b-582d619b4e74.png">
<img width="664" alt="Screen Shot 2019-05-31 at 10 15 06 AM" src="https://user-images.githubusercontent.com/12106730/58723145-350ab680-838e-11e9-842a-1b9d3fd8d6ff.png">

 - Mobile list view looks good when scrolled all the way to the bottom:
<img width="664" alt="Screen Shot 2019-05-31 at 10 15 10 AM" src="https://user-images.githubusercontent.com/12106730/58723152-389e3d80-838e-11e9-99a9-fa454aea6c8b.png">