### PR TITLE
Add a permission dialog before uploading media to firebase

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -5,6 +5,7 @@ import axios from 'axios';
 import Button from '@material-ui/core/Button';
 import MenuItem from '@material-ui/core/MenuItem';
 import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 
@@ -70,7 +71,8 @@ class Form extends Component {
     media: null,
     mediaPaths: [],
     thanksMessage: null,
-    submitting: false
+    submitting: false,
+    permissionOpen: false,
   };
 
   constructor(props) {
@@ -87,7 +89,7 @@ class Form extends Component {
   };
 
   handleSubmit = () => {
-    let {thanksMessage, submitting, ...report} = this.state;
+    let {thanksMessage, submitting, permissionOpen, ...report} = this.state;
     delete report['media'];
     this.setState({submitting: true});
     return axios.post(addReportUrl, report)
@@ -123,6 +125,13 @@ class Form extends Component {
     }
   };
 
+  handlePermissionResponse = (agree) => {
+    this.setState({permissionOpen: false});
+    if (agree) {
+      this.uploadMedia();
+    }
+  }
+
   handleClose = () => {
     const { history, handleDrawerState, fromDrawer } = this.props;
     this.setState({thanksMessage: null}, () => {
@@ -138,7 +147,8 @@ class Form extends Component {
       mapLat, mapLng, timestamp, animalFeatures, species, confidence, numberOfAdultSpecies,
       numberOfYoungSpecies, numberOfAdults, numberOfChildren, reaction, reactionDescription, numberOfDogs, dogSize,
       onLeash, animalBehavior, animalEating, vocalization, vocalizationDesc, carnivoreResponse, carnivoreConflict,
-      conflictDesc, contactName, contactEmail, contactPhone, generalComments, mediaPaths, thanksMessage, submitting
+      conflictDesc, contactName, contactEmail, contactPhone, generalComments, mediaPaths, thanksMessage, submitting,
+      permissionOpen
     } = this.state;
 
     return (
@@ -419,7 +429,8 @@ class Form extends Component {
             <MediaUpload uploadMedia={this.setMedia} getMediaPaths={this.handleUploadSuccess}/>
             {mediaPaths.length > 0 ? <p>{mediaPaths.length} files uploaded</p> : null}
           </div>
-          <Button size="small" color="secondary" variant="contained" onClick={() => this.uploadMedia()}>Upload</Button>
+          {/* Setting permissionOpen to true opens the permission dialog, where clicking "agree" actually calls the media upload function */}
+          <Button size="small" color="secondary" variant="contained" onClick={() => this.setState({ permissionOpen: true })}>Upload</Button>
 
           <div className="formItem">
             <h4>How many humans were in your group?</h4>
@@ -612,6 +623,7 @@ class Form extends Component {
             Submit
           </Button>
         </ValidatorForm>
+        {/* "Thanks for submitting" dialog */}
         <Dialog
           open={thanksMessage}
           onClose={this.handleClose}
@@ -621,6 +633,25 @@ class Form extends Component {
               {thanksMessage}
             </DialogContentText>
           </DialogContent>
+        </Dialog>
+        {/* Permission dialog */}
+        <Dialog
+          open={permissionOpen}
+          onClose={() => this.setState({ permissionOpen: false })}
+        >
+          <DialogContent>
+            <DialogContentText>
+              Is it ok if we store the images and audio that you've uploaded? If you say no, we will not be able to show your pictures to other users.
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => this.handlePermissionResponse(false)} color="primary">
+              No, don't use my media
+            </Button>
+            <Button onClick={() => this.handlePermissionResponse(true)} color="primary">
+              Yes, use my media
+            </Button>
+          </DialogActions>
         </Dialog>
       </div>
       </LoadingOverlay>


### PR DESCRIPTION
The add-media buttons don't have a hook between a user clicking on the box and opening the file select dialog, so I wasn't able to add the permission dialog at that point.

However, I was able to add a permission dialog upon hitting the upload button, which looks like this:

![image](https://user-images.githubusercontent.com/12106730/58724242-ef032200-8390-11e9-8d7c-e7a61860efd0.png)

The user experience for this part of the form is still a little weird -- if we end up having time we might want to look into this. Even just a little bit of text showing that there are some files "on deck" but not actually added to the report might be helpful.