### PR TITLE
List view has a filter on desktop, and it's responsive

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -217,6 +217,7 @@ List + Card
     padding-top: 100px;
     padding-bottom: 20px;
     background-color: #ececec;
+    min-height: 100vh;
 }
 
 .cardContainer {

--- a/src/App.css
+++ b/src/App.css
@@ -227,6 +227,7 @@ List + Card
     align-items: center;
     flex-direction: column;
     justify-content: center;
+    margin-left: 0;
 }
 
 .card {
@@ -240,6 +241,17 @@ List + Card
     width: 150px;
 }
 
+.filterContainer {
+    background-color: white;
+    position: fixed;
+    left: 5%;
+    top: 15%;
+    width: 250px;
+    z-index: 1;
+    height: 60%;
+    box-shadow: 2px 2px 2px;
+}
+
 @media (min-width: 600px) {
     .card {
         width: 550px;
@@ -251,10 +263,11 @@ List + Card
     .cardContainer {
         margin-top: 80px;
         margin-bottom: 0;
+        margin-left: 40%;
     }
 
     .card {
-        width: 650px;
+        width: 500px;
         height: 200px;
     }
 
@@ -264,6 +277,25 @@ List + Card
     }
 }
 
+@media (min-width: 1024px) {
+    .card {
+        width: 600px;
+    }
+
+    .cardContainer {
+        margin-left: 30%;
+    }
+}
+
+@media (min-width: 1440px) {
+    .card {
+        width: 800px;
+    }
+
+    .cardContainer {
+        margin-left: 20%
+    }
+}
 /*
 Report Viewer
  */

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import ListCard from '../components/ListCard';
 import { dataMatchesFilter } from '../services/FilterService';
+import FilterDrawer from './FilterDrawer';
 
 const getReports = 'https://us-central1-seattlecarnivores-edca2.cloudfunctions.net/getReports';
 
@@ -23,12 +24,17 @@ class ListView extends Component {
 
   render() {
     const { reports } = this.state;
-    const { filter } = this.props;
+    const { filter, isMobile } = this.props;
     if (!reports) {
       return <CircularProgress/>;
     }
     return (
       <div className="backgroundCardContainer">
+        { isMobile ? null :
+          <div className="filterContainer">
+            <FilterDrawer />
+          </div>
+        }
         <div className="cardContainer">
           {reports.filter(report => dataMatchesFilter(report, filter))
             .map((report) => <ListCard data={report.data} key={report.id}/>)}


### PR DESCRIPTION
This PR adds a filter view to the desktop list view. In order to make it look good, I shrunk the default card size and used some [@media magic](https://www.w3schools.com/cssref/css3_pr_mediaquery.asp) to make it resize/stretch properly without overlapping at a variety of sizes. We can adjust these numbers if we find a spot where it looks gnarly, but I quickly ran through a couple and it looked decent. 

In an ideal world, the filter would actually have a static position displayed by some kind of flex thing, but I had a lot of trouble getting that running cleanly. So instead it's positioned absolute and then we just adjust the left margin of the list view as the window shrinks/expands. I'm not a huge fan of this solution but it seems to do the trick.

**Screenshots:**
Big desktop view:
![image](https://user-images.githubusercontent.com/12106730/58922733-0a539180-86f1-11e9-9471-e52fd415707d.png)
Smaller desktop view:
![image](https://user-images.githubusercontent.com/12106730/58922749-16d7ea00-86f1-11e9-87dd-395b12ecc624.png)
Smallest desktop view:
![image](https://user-images.githubusercontent.com/12106730/58922756-248d6f80-86f1-11e9-88d7-e4035b90975c.png)
Mobile is unchanged:
![image](https://user-images.githubusercontent.com/12106730/58922761-2e16d780-86f1-11e9-9f25-c244981a07d9.png)
