### PR TITLE
Automatically send emails upon submissions

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -4285,6 +4285,11 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.4.tgz",
       "integrity": "sha512-8Df0906+tq/omxuCZD6PqhPaQDYuyJ1d+VITgxoIA8zvQd1ru+nMJcDChHH324MWitIgbVkAkQoGEEVJNpn/PA=="
     },
+    "nodemailer": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.2.1.tgz",
+      "integrity": "sha512-TagB7iuIi9uyNgHExo8lUDq3VK5/B0BpbkcjIgNvxbtVrjNqq0DwAOTuzALPVkK76kMhTSzIgHqg8X1uklVs6g=="
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,6 +16,7 @@
     "firebase-admin": "~7.0.0",
     "firebase-functions": "^2.2.0",
     "moment": "^2.24.0",
+    "nodemailer": "^6.2.1",
     "turf-point": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR wraps up automatic emails. Currently they're directed at my personal email, but it's really easy to switch that around.

For the sender, I signed up for a simple gmail account -- talk to me if you'd like the login information, or you can get the username and password by running `firebase functions:config:get`.

We should eventually do the following things:

 - move the report_url_stub so we can deploy this for production and staging easily
 - update the email to a more professional-looking account
 - update the recipients to whoever the zoo wants

An email from this service looks like this:
![image](https://user-images.githubusercontent.com/12106730/59132256-8b956900-8929-11e9-8f99-3f64676e99c9.png)
I've verified that the link works properly.