### PR TITLE
Mobile Form Map Experience Improvements

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -76,7 +76,6 @@ class Footer extends Component {
           anchor="bottom"
           open={open}
           onClose={this.toggleDrawer(!open)}
-          onOpen={this.toggleDrawer(!open)}
           className="formWizard"
         >
           <div tabIndex={0}>

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -5,7 +5,7 @@ import MapIcon from '@material-ui/icons/Map';
 import SettingsIcon from '@material-ui/icons/Settings';
 import Button from '@material-ui/core/Button';
 import Fab from '@material-ui/core/Fab';
-import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
+import Drawer from '@material-ui/core/Drawer';
 import { withStyles } from '@material-ui/core/styles';
 
 import Form from './Form';
@@ -72,7 +72,7 @@ class Footer extends Component {
         <Fab color="primary" aria-label="Add" className="plusButton" size="large" onClick={this.toggleDrawer(!open)}>
           <AddIcon/>
         </Fab>
-        <SwipeableDrawer
+        <Drawer
           anchor="bottom"
           open={open}
           onClose={this.toggleDrawer(!open)}
@@ -87,7 +87,7 @@ class Footer extends Component {
             </div>
             <Form handleDrawerState={this.handleDrawer} fromDrawer/>
           </div>
-        </SwipeableDrawer>
+        </Drawer>
         <Button className="footerIcons" style={{ float: 'right', marginRight: '50px' }}>
           <SettingsIcon style={{ color: 'gray' }}/>
           <p>Resources</p>

--- a/src/components/FormMap.js
+++ b/src/components/FormMap.js
@@ -2,10 +2,17 @@ import React, { Component } from 'react';
 import ReactMapboxGl, { Layer, Feature } from 'react-mapbox-gl';
 
 const Map = ReactMapboxGl({
-  accessToken: process.env.REACT_APP_MAPBOX_TOKEN
+  accessToken: process.env.REACT_APP_MAPBOX_TOKEN,
+    dragPan: false
 });
 
 class FormMap extends Component {
+
+  doNotPropagate = e => {
+      e.originalEvent.stopPropagation();
+      e.originalEvent.preventDefault();
+  };
+
 
   onDragEnd = e => {
     const { passMapCoordinates } = this.props;
@@ -22,13 +29,16 @@ class FormMap extends Component {
       <div>
         <Map style="mapbox://styles/mapbox/streets-v9"
              center={{ lng: centerLng, lat: centerLat }}
-             className="formMap">
+             className="formMap"
+             onTouchMove={(map, e) => this.doNotPropagate(e)}
+        >
           <Layer type="circle"
                  id="marker"
                  paint={{
                    'circle-color': '#ff5200',
                    'circle-stroke-width': 1,
-                   'circle-stroke-opacity': 1
+                   'circle-stroke-opacity': 1,
+                   'circle-radius': 10
                  }}>
             <Feature coordinates={[centerLng, centerLat]} draggable
                      onDragEnd={e => this.onDragEnd(e)}/>

--- a/src/components/FormMap.js
+++ b/src/components/FormMap.js
@@ -13,7 +13,6 @@ class FormMap extends Component {
       e.originalEvent.preventDefault();
   };
 
-
   onDragEnd = e => {
     const { passMapCoordinates } = this.props;
     const lng = e.lngLat.lng;


### PR DESCRIPTION
The form map is pretty hard to use on mobile at the moment, and this makes it a little better:

 - Increased the radius of the draggable button so it'll be easier to start a drag gesture.
 - Made the form drawer not swipeable on mobile -- I kept on accidentally closing the form while scrolling around whenever I hit some lag. I think having the submit at the bottom and the x at the top is good enough but we can discuss.
 - Turned dragPan off for the map. So whenever a drag happens on the map it's clearly moving the dot and not panning the map.
 - The map listens for onTouchMove events and blocks them from propagating, so moving your finger around on the map doesn't scroll the whole page.

We could also consider doing something where the marker stays still in the center and you drag the map around behind it a la Lyft/Uber.

Here's a picture:
![image](https://user-images.githubusercontent.com/12106730/59169030-59346900-8aed-11e9-93f1-c6a4a186c4e1.png)
