### PR TITLE
Styling and behavior on the popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-firebase-file-uploader": "^2.4.2",
     "react-image-gallery": "^0.8.16",
     "react-loading-overlay": "^1.0.1",
-    "react-mapbox-gl": "^4.2.0",
+    "react-mapbox-gl": "~4.2.0",
     "react-material-ui-form-validator": "^2.0.7",
     "react-redux": "^7.0.3",
     "react-responsive-carousel": "^3.1.49",

--- a/src/App.css
+++ b/src/App.css
@@ -375,10 +375,6 @@ Footer Styles
 
 }
 
-.caption {
-    font-weight: bold;
-}
-
 .carouselContainer {
     width: 275px;
     height: 275px;

--- a/src/components/MapView.js
+++ b/src/components/MapView.js
@@ -61,15 +61,13 @@ class MapView extends Component {
         const {popupInfo} = this.state;
         if(popupInfo)
         {
-            return (
-                <Popup tipSize={5}
-                       anchor="bottom"
-                       coordinates={[popupInfo.data.mapLng, popupInfo.data.mapLat]}
-                       className="cardContainer"
-                       onMouseLeave={() => this.setState({popupInfo: false})}>
-                    <PointTooltip className="mapboxgl-popup-content" report={popupInfo} key={popupInfo.id}/>
-                </Popup>
-            );
+            return <Popup
+                    coordinates={[popupInfo.data.mapLng, popupInfo.data.mapLat]}
+                    onClick={() => this.setState({popupInfo: false})}
+                    anchor={"bottom"}
+            >
+                <PointTooltip report={popupInfo} />
+            </Popup>
         }
     }
 

--- a/src/components/PointTooltip.js
+++ b/src/components/PointTooltip.js
@@ -1,8 +1,7 @@
 import React, {Component} from 'react';
 import { withStyles } from '@material-ui/core/styles';
-import {Link} from "react-router-dom";
-import {KeyboardArrowLeft} from "@material-ui/icons";
-import Button from "./ReportViewer";
+import { withRouter } from 'react-router-dom';
+import {KeyboardArrowRight} from "@material-ui/icons";
 
 const DEFAULT_IMAGE_URL = "https://upload.wikimedia.org/wikipedia/commons/thumb/7/79/2010-brown-bear.jpg/200px-2010-brown-bear.jpg";
 
@@ -11,22 +10,44 @@ const timeToString = time => {
     return `${date.toDateString()} ${date.getHours()}:${date.getMinutes()}`;
 };
 
+const styles = {
+    allContent: {
+        display: 'flex',
+        height: 80,
+    },
+    caption: {
+        fontWeight: 'bold'
+    },
+    reportLink: {
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+    },
+    image: {
+        maxWidth: 40,
+        maxHeight: 40,
+        margin: 4
+    }
+};
 
 /* TODO: Should be updated with neighborhood info */
 class PointTooltip extends Component {
     render() {
-        const { report } = this.props;
-        return <div >
-            <img width = {40} src = {report.data.mediaPaths && report.data.mediaPaths.length>0 ? report.data.mediaPaths[0] : DEFAULT_IMAGE_URL}  />
-            <div className = "caption">{report.data.species}</div>
-            <div className = "caption">Date & Time:</div>
-            <div>{timeToString(report.data.timestamp)}</div>
-            <div className = "caption">Location: {report.data.mapLat},{report.data.mapLng}</div>
-            <li>
-                <Link to={`/reports/${report.id}`}>See Report</Link>
-            </li>
+        const { report, classes, history } = this.props;
+        return <div className={classes.allContent}>
+            <img className={classes.image} src = {report.data.mediaPaths && report.data.mediaPaths.length>0 ? report.data.mediaPaths[0] : DEFAULT_IMAGE_URL}  />
+            <div className={classes.info}>
+                <div><strong>{report.data.species}</strong></div>
+                <div><strong>Date & Time:</strong></div>
+                <div>{timeToString(report.data.timestamp)}</div>
+                <div><strong>Location:</strong> {report.data.neighborhood}</div>
+            </div>
+            <div className={classes.reportLink} onClick={() => history.push(`/reports/${report.id}`)}>
+                <KeyboardArrowRight/>
+            </div>
         </div>
     }
 };
 
-export default PointTooltip;
+export default withStyles(styles)(withRouter(PointTooltip));


### PR DESCRIPTION
Cleans up the map popup a little bit, reworking the structure a tiny bit:
![image](https://user-images.githubusercontent.com/12106730/59234950-f225bb80-8ba3-11e9-94ef-ecb07d913b76.png)

At the moment, you can click a feature to display a popup and click the popup anywhere except the arrow to close it. In the future we should handle clicking on the map but not on a feature to close the popup as well. I took a stab at it but it's pretty tricky and I ran out of time -- we can come back to it later.