### PR TITLE
Filter fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7282,6 +7282,11 @@
         }
       }
     },
+    "css-supports": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/css-supports/-/css-supports-0.1.1.tgz",
+      "integrity": "sha1-muIB+VK+tl8AxeSySevOjvWKAT0="
+    },
     "css-tree": {
       "version": "1.0.0-alpha.28",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
@@ -17863,6 +17868,15 @@
         }
       }
     },
+    "react-sticky-fill": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/react-sticky-fill/-/react-sticky-fill-0.8.4.tgz",
+      "integrity": "sha512-EQVDR/iN0KP89Mogon69KgCVbfRQxQe/73G3gzMW7ZfDOv1khQjpvn+0FVvgTKcp/AjJz/T4QhNZp2/oNiQdww==",
+      "requires": {
+        "css-supports": "^0.1.1",
+        "stickyfill": "^1.1.1"
+      }
+    },
     "react-swipeable": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-4.3.2.tgz",
@@ -19833,6 +19847,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
+    "stickyfill": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stickyfill/-/stickyfill-1.1.1.tgz",
+      "integrity": "sha1-OUE/7p0CXHSn5ZzuyyN4TMDxfwI="
     },
     "stream-browserify": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
     "react-scripts": "^2.1.8",
+    "react-sticky-fill": "^0.8.4",
     "react-swipeable-views": "^0.13.3",
     "react-swipeable-views-utils": "^0.13.3",
     "redux": "^4.0.1"

--- a/src/components/FilterCheckboxes.js
+++ b/src/components/FilterCheckboxes.js
@@ -41,20 +41,26 @@ class FilterCheckboxes extends Component {
                         className={classes.checkbox}/>} label={label}/>
     };
 
+    orderEntries = filter => {
+        return Object.entries(filter)
+          // Sort the entries by their order
+          .sort(([aKey, aValue], [otherKey, otherValue]) => aValue.order - otherValue.order)
+    };
+
     render() {
         const {allLabel, briefNumber, filter, updateValues, classes, keyColorFunction} = this.props;
         const {viewAll} = this.state;
         return <FormControl component="fieldset" className={classes.allContent}>
             <FormGroup>
                 <FormControlLabel
-                    control={<Checkbox checked={filter['all']}
-                                onChange={() => updateValues('all', !filter['all'])}
+                    control={<Checkbox checked={filter['all'].value}
+                                onChange={() => updateValues('all', !filter['all'].value)}
                                 checkedIcon={<CheckBoxIntermediateIcon className={classes.checkedCheckbox}/>}
                                 className={classes.checkbox}/>}
                     label={allLabel} />
-                {Object.entries(filter)
-                    .filter(([key, value]) => key !== 'all').slice(0, briefNumber).map(([itemKey, checked]) =>
-                    this.getButton(itemKey, checked, () => updateValues(itemKey, !checked), classes, keyColorFunction)
+                {this.orderEntries(filter)
+                    .filter(([key, value]) => key !== 'all').slice(0, briefNumber).map(([itemKey, itemState]) =>
+                    this.getButton(itemKey, itemState.value, () => updateValues(itemKey, !itemState.value), classes, keyColorFunction)
                 )}
             </FormGroup>
             {/* Button to display the rest. Subtracting 1 to account for the all button, which has a field in filter
@@ -63,9 +69,9 @@ class FilterCheckboxes extends Component {
                 <>
                 <Collapse in={viewAll}>
                     <FormGroup>
-                        {Object.entries(filter).filter(([key, value]) => key !== 'all').slice(briefNumber)
-                            .map(([itemKey, checked]) =>
-                                this.getButton(itemKey, checked, () => updateValues(itemKey, !checked), classes))}
+                        {this.orderEntries(filter).filter(([key, value]) => key !== 'all').slice(briefNumber)
+                            .map(([itemKey, itemState]) =>
+                                this.getButton(itemKey, itemState.value, () => updateValues(itemKey, !itemState.value), classes))}
                     </FormGroup>
                 </Collapse>
                 <Button

--- a/src/components/FilterCheckboxes.js
+++ b/src/components/FilterCheckboxes.js
@@ -31,14 +31,13 @@ class FilterCheckboxes extends Component {
         };
     }
 
-    getButton = (itemKey, checked, disabled, onChange, classes, keyColorFunction) => {
+    getButton = (itemKey, checked, onChange, classes, keyColorFunction) => {
         const label = keyColorFunction ? <span><PlaceIcon style={{color: keyColorFunction(itemKey)}}/>{itemKey}</span> : <span>{itemKey}</span>;
         return <FormControlLabel key={itemKey}
                     control={<Checkbox
                         checkedIcon={<CheckBoxIntermediateIcon className={classes.checkedCheckbox}/>}
                         checked={checked}
                         onChange={onChange}
-                        disabled={disabled}
                         className={classes.checkbox}/>} label={label}/>
     };
 
@@ -55,7 +54,7 @@ class FilterCheckboxes extends Component {
                     label={allLabel} />
                 {Object.entries(filter)
                     .filter(([key, value]) => key !== 'all').slice(0, briefNumber).map(([itemKey, checked]) =>
-                    this.getButton(itemKey, checked, filter['all'], () => updateValues(itemKey, !checked), classes, keyColorFunction)
+                    this.getButton(itemKey, checked, () => updateValues(itemKey, !checked), classes, keyColorFunction)
                 )}
             </FormGroup>
             {/* Button to display the rest. Subtracting 1 to account for the all button, which has a field in filter
@@ -66,7 +65,7 @@ class FilterCheckboxes extends Component {
                     <FormGroup>
                         {Object.entries(filter).filter(([key, value]) => key !== 'all').slice(briefNumber)
                             .map(([itemKey, checked]) =>
-                                this.getButton(itemKey, checked, filter['all'], () => updateValues(itemKey, !checked), classes))}
+                                this.getButton(itemKey, checked, () => updateValues(itemKey, !checked), classes))}
                     </FormGroup>
                 </Collapse>
                 <Button

--- a/src/components/FilterCheckboxes.js
+++ b/src/components/FilterCheckboxes.js
@@ -7,9 +7,6 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import PlaceIcon from '@material-ui/icons/Place';
 
 const styles = {
-    checkbox: {
-        margin: '0px 0px 0px 8px',
-    },
     checkedCheckbox: {
         color: '#93C838'
     },
@@ -17,6 +14,7 @@ const styles = {
         margin: 'auto'
     },
     allContent: {
+        padding: '0px 0px 0px 24px',
         width: '100%'
     }
 };
@@ -37,8 +35,7 @@ class FilterCheckboxes extends Component {
                     control={<Checkbox
                         checkedIcon={<CheckBoxIntermediateIcon className={classes.checkedCheckbox}/>}
                         checked={checked}
-                        onChange={onChange}
-                        className={classes.checkbox}/>} label={label}/>
+                        onChange={onChange}/>} label={label}/>
     };
 
     orderEntries = filter => {
@@ -55,8 +52,7 @@ class FilterCheckboxes extends Component {
                 <FormControlLabel
                     control={<Checkbox checked={filter['all'].value}
                                 onChange={() => updateValues('all', !filter['all'].value)}
-                                checkedIcon={<CheckBoxIntermediateIcon className={classes.checkedCheckbox}/>}
-                                className={classes.checkbox}/>}
+                                checkedIcon={<CheckBoxIntermediateIcon className={classes.checkedCheckbox}/>}/>}
                     label={allLabel} />
                 {this.orderEntries(filter)
                     .filter(([key, value]) => key !== 'all').slice(0, briefNumber).map(([itemKey, itemState]) =>

--- a/src/components/FilterDrawer.js
+++ b/src/components/FilterDrawer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
-import { Button, Collapse, Fab, FormControl, FormControlLabel, FormGroup, Checkbox, IconButton} from '@material-ui/core';
+import { Button, Collapse, Card, FormControl, FormControlLabel, FormGroup, Checkbox} from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import RemoveIcon from '@material-ui/icons/Remove';
 import FilterCheckboxes from './FilterCheckboxes';
@@ -39,17 +39,8 @@ const styles = {
     mainContent: {
         flex: 1
     },
-    resultsButton: {
-        position: 'sticky',
-        bottom: 4,
-        left: '5%',
-        width: '90%',
-        justifyContent: 'center',
-        color: 'white',
-        backgroundColor: '#93C838'
-    },
     expandHeader: {
-        margin: 16,
+        margin: '16px 16px 16px 24px',
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center'
@@ -59,6 +50,9 @@ const styles = {
     },
     collapsible: {
         textAlign: 'left'
+    },
+    separator: {
+        margin: 0
     }
 };
 
@@ -119,13 +113,13 @@ class FilterDrawer extends React.Component {
     }
 
     render = () => {
-        const {classes, cancel, children, filter: {startDate, endDate, confidenceFilterActive, carnivoreFilter, neighborhoodFilter, timeFilter}} = this.props;
+        const {classes, close, children, filter: {startDate, endDate, confidenceFilterActive, carnivoreFilter, neighborhoodFilter, timeFilter}} = this.props;
         const {showCarnivores, showNeighborhoods, showTime, showConfidence, dateRangeFocused} = this.state;
         return (
             <div className={classes.allContent}>
                 {children}
                 <div className={classes.header}>
-                    {cancel && <Button onClick={cancel}>Cancel</Button> }
+                    {close && <Button onClick={close}>Close</Button> }
                     <h3>Filter</h3>
                     <Button onClick={resetFilter}>Reset</Button>
                 </div>
@@ -139,7 +133,7 @@ class FilterDrawer extends React.Component {
                             briefNumber={Object.keys(carnivoreFilter).length - 1}
                             keyColorFunction={getColorForSpecies}/>
                     )}
-                    <hr/>
+                    <hr className={classes.separator}/>
 
                     {/* Neighborhoods */}
                     {this.getCollapse(classes, "Neighborhood", this.toggleShow('showNeighborhoods'), showNeighborhoods,
@@ -149,7 +143,7 @@ class FilterDrawer extends React.Component {
                             updateValues={this.updateFilterSubsection('neighborhoodFilter')}
                             briefNumber={briefNeighborhoodsCount}/>
                     )}
-                    <hr/>
+                    <hr className={classes.separator}/>
 
                     {/* Time and Day */}
                     {this.getCollapse(classes, "Time of Sighting", this.toggleShow('showTime'), showTime,
@@ -176,7 +170,7 @@ class FilterDrawer extends React.Component {
                                 briefNumber={Object.keys(timeFilter).length - 1}/>
                         </>
                     )}
-                    <hr/>
+                    <hr className={classes.separator}/>
 
                     {/* Confidence */}
                     {this.getCollapse(classes, "Confidence of Sighting", this.toggleShow('showConfidence'), showConfidence,

--- a/src/components/FilterDrawer.js
+++ b/src/components/FilterDrawer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
-import { Button, Collapse, Fab, FormControl, FormControlLabel, FormGroup, Checkbox} from '@material-ui/core';
+import { Button, Collapse, Fab, FormControl, FormControlLabel, FormGroup, Checkbox, IconButton} from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import RemoveIcon from '@material-ui/icons/Remove';
 import FilterCheckboxes from './FilterCheckboxes';
@@ -8,6 +8,7 @@ import CheckBoxIntermediateIcon from 'mdi-react/CheckboxIntermediateIcon'
 import { connect } from 'react-redux';
 import { updateFilter, updateFilterDate, toggleFilterConfidence, resetFilter } from '../store/actions'
 import { getColorForSpecies } from '../services/ColorService';
+import ResizableIconButton from './ResizableIconButton';
 
 // Date picker
 import 'react-dates/initialize';
@@ -31,7 +32,8 @@ const styles = {
         position: 'sticky',
         top: 0,
         backgroundColor: 'white',
-        zIndex: 1
+        zIndex: 1,
+        padding: '4px 24px 4px 24px',
     },
     filterBox: {},
     mainContent: {
@@ -46,18 +48,11 @@ const styles = {
         color: 'white',
         backgroundColor: '#93C838'
     },
-    expandButton: {
-        boxShadow: 'none',
-        float: 'right',
-        position: 'relative',
-        top: -8,
-        backgroundColor: '#93C838',
-        color: 'white'
-    },
     expandHeader: {
         margin: 16,
         display: 'flex',
-        justifyContent: 'space-between'
+        justifyContent: 'space-between',
+        alignItems: 'center'
     },
     headerTitle: {
         alignText: 'left'
@@ -104,13 +99,11 @@ class FilterDrawer extends React.Component {
         return <>
             <div className={classes.expandHeader}>
                 <span className={classes.headerTitle}>{headerTitle}</span>
-                <Fab
-                    className={classes.expandButton}
-                    onClick={onClick}
-                    size="small"
-                    disableRipple={true}>
-                        {expand ? <RemoveIcon /> : <AddIcon />}
-                </Fab>
+                <ResizableIconButton
+                  onClick={onClick}
+                  disableRipple={true}>
+                    {expand ? <RemoveIcon/> : <AddIcon/>}
+                </ResizableIconButton>
             </div>
             <Collapse in={expand} className={classes.collapsible}>
                 {child}
@@ -133,7 +126,7 @@ class FilterDrawer extends React.Component {
                 {children}
                 <div className={classes.header}>
                     {cancel && <Button onClick={cancel}>Cancel</Button> }
-                    <h3 style={{margin: 4}}>Filter</h3>
+                    <h3>Filter</h3>
                     <Button onClick={resetFilter}>Reset</Button>
                 </div>
                 <div className={classes.mainContent}>

--- a/src/components/FilterDrawer.js
+++ b/src/components/FilterDrawer.js
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import { updateFilter, updateFilterDate, toggleFilterConfidence, resetFilter } from '../store/actions'
 import { getColorForSpecies } from '../services/ColorService';
 import ResizableIconButton from './ResizableIconButton';
+import Sticky from 'react-sticky-fill';
 
 // Date picker
 import 'react-dates/initialize';
@@ -113,16 +114,17 @@ class FilterDrawer extends React.Component {
     }
 
     render = () => {
-        const {classes, close, children, filter: {startDate, endDate, confidenceFilterActive, carnivoreFilter, neighborhoodFilter, timeFilter}} = this.props;
+        const {classes, close, filter: {startDate, endDate, confidenceFilterActive, carnivoreFilter, neighborhoodFilter, timeFilter}} = this.props;
         const {showCarnivores, showNeighborhoods, showTime, showConfidence, dateRangeFocused} = this.state;
         return (
             <div className={classes.allContent}>
-                {children}
-                <div className={classes.header}>
-                    {close && <Button onClick={close}>Close</Button> }
-                    <h3>Filter</h3>
-                    <Button onClick={resetFilter}>Reset</Button>
-                </div>
+                <Sticky>
+                    <div className={classes.header}>
+                        {close && <Button onClick={close}>Close</Button> }
+                        <h3>Filter</h3>
+                        <Button onClick={resetFilter}>Reset</Button>
+                    </div>
+                </Sticky>
                 <div className={classes.mainContent}>
                     {/* Carnivores */}
                     {this.getCollapse(classes, "Type of Carnivore", this.toggleShow('showCarnivores'), showCarnivores,

--- a/src/components/MapView.js
+++ b/src/components/MapView.js
@@ -27,7 +27,7 @@ const styles = {
         backgroundColor: 'white',
         position: 'fixed',
         left: '5%',
-        top: '15%',
+        bottom: '5%',
         width: 250,
         zIndex: 1,
         height: '60%',

--- a/src/components/MobileHeader.js
+++ b/src/components/MobileHeader.js
@@ -51,7 +51,7 @@ class MobileHeader extends Component {
                 style={{ width: '250px' }}
               >
                 <div className={classes.filterContainer}>
-                  <FilterDrawer cancel={this.toggleDrawer('right', false)}/>
+                  <FilterDrawer close={this.toggleDrawer('right', false)}/>
                 </div>
               </div>
             </SwipeableDrawer>

--- a/src/components/ResizableIconButton.js
+++ b/src/components/ResizableIconButton.js
@@ -1,0 +1,23 @@
+import IconButton from '@material-ui/core/IconButton';
+import React from 'react';
+import {withStyles} from '@material-ui/core/styles';
+
+const ResizableIconButton = ({classes, ...props}) =>
+    <IconButton className={classes.small}
+                {...props}/>;
+
+const styles = {
+    small: {
+        '& svg': {
+          fontSize: 24,
+
+        },
+        width: 24,
+        height: 24,
+        padding: 0,
+        backgroundColor: '#93C838',
+        color: 'white',
+    }
+};
+
+export default withStyles(styles)(ResizableIconButton);

--- a/src/services/FilterService.js
+++ b/src/services/FilterService.js
@@ -48,7 +48,7 @@ const insideDateBounds = (target, startDate, endDate) => {
 
 const insideAnyActiveTimeBounds = (date, filter) => {
     const { timeFilter } = filter;
-    return DATE_BOUNDS.filter(bounds => timeFilter[bounds.name])
+    return DATE_BOUNDS.filter(bounds => timeFilter[bounds.name].value)
         .some(bounds => insideTimeBounds(date, bounds));
 }
 
@@ -64,16 +64,16 @@ const matchesOtherCarnivore = (filter, species) => {
 
 export const getInitialFilter = (allNeighborhoods) => {
     // Carnivore, neighborhood, and times defaults
-    const defaultCarnivoreFilter = {all: true};
-    allCarnivores.forEach(carnivore => defaultCarnivoreFilter[carnivore] = true);
+    const defaultCarnivoreFilter = {all: {order: 0, value: true}};
+    allCarnivores.forEach((carnivore, ind) => defaultCarnivoreFilter[carnivore] = {order: ind + 1, value: true});
     const defaultNeighborhoodFilter = allNeighborhoods
         .filter(hood => hood !== 'all')
-        .reduce((obj, neighborhood) => {
-            obj[neighborhood] = true;
+        .reduce((obj, neighborhood, index) => {
+            obj[neighborhood] = {order: index + 1, value: true};
             return obj;
-        }, {all: true});
-    const defaultTimeFilter = {all: true};
-    allTimes.forEach(time => defaultTimeFilter[time] = true);
+        }, {all: {order: 0, value: true}});
+    const defaultTimeFilter = {all: {order: 0, value: true}};
+    allTimes.forEach((time, ind) => defaultTimeFilter[time] = {order: ind+1, value: true});
 
     const initialFilter = {
         carnivoreFilter: {...defaultCarnivoreFilter},
@@ -93,13 +93,13 @@ export const dataMatchesFilter = (report, filter) => {
     const { data } = report;
     const parsedDate = new Date(data.timestamp);
     // ok with species    
-    return (filter.carnivoreFilter.all || filter.carnivoreFilter[data.species] || matchesOtherCarnivore(filter, data.species)) &&
+    return (filter.carnivoreFilter.all.value || filter.carnivoreFilter[data.species].value || matchesOtherCarnivore(filter, data.species)) &&
     // ok with neighborhood
-    (filter.neighborhoodFilter.all === true || (data.hasOwnProperty('neighborhood') && filter.neighborhoodFilter[data.neighborhood] === true)) &&
+    (filter.neighborhoodFilter.all.value === true || (data.hasOwnProperty('neighborhood') && filter.neighborhoodFilter[data.neighborhood].value === true)) &&
     // ok with date
     insideDateBounds(moment(parsedDate), filter.startDate, filter.endDate) &&
     // ok with time
-    (filter.timeFilter.all || insideAnyActiveTimeBounds(parsedDate, filter)) &&
+    (filter.timeFilter.all.value || insideAnyActiveTimeBounds(parsedDate, filter)) &&
     // ok with confidence
     (!filter.confidenceFilterActive || data.confidence === HIGH_CONFIDENCE || data.confidence === MEDIUM_CONFIDENCE);
 }

--- a/src/services/FilterService.js
+++ b/src/services/FilterService.js
@@ -65,15 +65,15 @@ const matchesOtherCarnivore = (filter, species) => {
 export const getInitialFilter = (allNeighborhoods) => {
     // Carnivore, neighborhood, and times defaults
     const defaultCarnivoreFilter = {all: true};
-    allCarnivores.forEach(carnivore => defaultCarnivoreFilter[carnivore] = false);
+    allCarnivores.forEach(carnivore => defaultCarnivoreFilter[carnivore] = true);
     const defaultNeighborhoodFilter = allNeighborhoods
         .filter(hood => hood !== 'all')
         .reduce((obj, neighborhood) => {
-            obj[neighborhood] = false;
+            obj[neighborhood] = true;
             return obj;
         }, {all: true});
     const defaultTimeFilter = {all: true};
-    allTimes.forEach(time => defaultTimeFilter[time] = false);
+    allTimes.forEach(time => defaultTimeFilter[time] = true);
 
     const initialFilter = {
         carnivoreFilter: {...defaultCarnivoreFilter},

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -20,15 +20,15 @@ const updateFilterReducer = (oldFilter, key, value) => {
         // turning all on should also turn on all other values inside of this filter
         // similarly, turning all off should also turn off all other values inside of this filter
         return Object.keys(oldFilter)
-          .reduce((object, newKey) => ({...object, [newKey]: value}), {});
+          .reduce((object, newKey) => ({...object, [newKey]: {...oldFilter[newKey], value}}), {});
     }
     else {
         // update the value
-        const newFilter = {...oldFilter, [key]: value};
+        const newFilter = {...oldFilter, [key]: {...oldFilter[key], value}};
         // If all are now true, set 'all' to true. Otherwise set 'all' to false
-        newFilter.all = Object.entries(newFilter)
+        newFilter.all = {order: 0, value: Object.entries(newFilter)
           .filter(([key, val]) => key !== 'all')
-          .every(([key, val]) => val === true);
+          .every(([key, val]) => val.value === true)};
         return newFilter;
     }
 };
@@ -56,10 +56,10 @@ const reducer = (state, action) => {
         // When we update the list of all neighborhoods, the filter should contain
         // all neighborhoods: false, plus an all: true.
         case UPDATE_ALL_NEIGHBORHOODS:
-            const newFilter = action.value.reduce((obj, neighborhood) => {
-                obj[neighborhood] = false;
+            const newFilter = action.value.reduce((obj, neighborhood, index) => {
+                obj[neighborhood] = {order: index, value: true};
                 return obj;
-            }, {all: true});
+            }, {all: {order: 0, value: true}});
             return {...state,
                 filter: {...state.filter,
                     neighborhoodFilter: newFilter

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -4,18 +4,43 @@ import { getInitialFilter } from '../services/FilterService';
 const initialState = {
     filter: getInitialFilter([]),
     isMobile: false,
-}
+};
+
+/**
+ * Given a filter and a new key/value pair, update the filter appropriately. Automatically handles the logic for the
+ * 'all' checkbox.
+ * @param oldFilter - a subset of the filter for a previous state. For example, the carnivore filter
+ * @param key - the key at which we want to change a value
+ * @param value - the new value we want to set
+ * @returns {{}} - a new filter with an appropriate value for 'all' and the new key/value pair.
+ */
+const updateFilterReducer = (oldFilter, key, value) => {
+    // The all key has some special behavior
+    if (key === 'all') {
+        // turning all on should also turn on all other values inside of this filter
+        // similarly, turning all off should also turn off all other values inside of this filter
+        return Object.keys(oldFilter)
+          .reduce((object, newKey) => ({...object, [newKey]: value}), {});
+    }
+    else {
+        // update the value
+        const newFilter = {...oldFilter, [key]: value};
+        // If all are now true, set 'all' to true. Otherwise set 'all' to false
+        newFilter.all = Object.entries(newFilter)
+          .filter(([key, val]) => key !== 'all')
+          .every(([key, val]) => val === true);
+        return newFilter;
+    }
+};
+
 const reducer = (state, action) => {
     switch(action.type) {
         case SET_MOBILE:
-            return {...state, isMobile: action.value}
+            return {...state, isMobile: action.value};
         case UPDATE_FILTER:
             return {...state, filter: {...state.filter,
-                [action.filterName]: {
-                    ...state.filter[action.filterName],
-                    [action.key]: action.newValue
-                }}
-            }
+                [action.filterName]: updateFilterReducer(state.filter[action.filterName], action.key, action.newValue)}
+            };
         case RESET_FILTER:
             const allNeighborhoods = Object.keys(state.filter.neighborhoodFilter);
             return {...state, filter: getInitialFilter(allNeighborhoods)};
@@ -23,11 +48,11 @@ const reducer = (state, action) => {
             return {...state, filter: {...state.filter,
                 startDate: action.startDate,
                 endDate: action.endDate}
-            }
+            };
         case TOGGLE_FILTER_CONFIDENCE:
             return {...state, filter: {...state.filter,
                 confidenceFilterActive: !state.filter.confidenceFilterActive}
-            }
+            };
         // When we update the list of all neighborhoods, the filter should contain
         // all neighborhoods: false, plus an all: true.
         case UPDATE_ALL_NEIGHBORHOODS:
@@ -41,6 +66,6 @@ const reducer = (state, action) => {
                 }}
     }
     return state;
-}
+};
 
 export {reducer, initialState};


### PR DESCRIPTION
This makes a couple of styling/functionality changes to the filters:

 - Clicking "all" is a little more intuitive now. The "all" button is automatically selected when all options have been selected, and toggling the button toggles all of the other options. @sayas01 I think you recommended something like this earlier -- great call. 
 - On safari, the options were re-ordering whenever a user clicked a button. I've added an `order` field to ensure that the order remains constant.
 - The expand buttons are now styled smaller, the map is in a better location, and I fixed some of the styling and spacing around the header
 - Cancel is now named close. Do we even need this button? Not sure.
 - Safari also had some issues with the header behaving properly with position: sticky, which I've addressed by using [this handy polyfill](https://www.npmjs.com/package/react-sticky-fill)

Desktop styling:
![image](https://user-images.githubusercontent.com/12106730/59472813-a7e74900-8df4-11e9-8f15-801ee24dd92b.png)
(expanded):
![image](https://user-images.githubusercontent.com/12106730/59472834-b59cce80-8df4-11e9-91ed-026ce0203782.png)
Result after clicking "all carnivores" once:
![image](https://user-images.githubusercontent.com/12106730/59472849-c3eaea80-8df4-11e9-9530-6215c8fe29e5.png)
Mobile filters:
![image](https://user-images.githubusercontent.com/12106730/59472873-d8c77e00-8df4-11e9-9ee0-4f2787f1d19f.png)

