### PR TITLE
Fix list filter bug (+ a minor css fix)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -241,7 +241,7 @@ List + Card
     background-color: white;
     position: fixed;
     left: 5%;
-    top: 15%;
+    bottom: 5%;
     width: 250px;
     z-index: 1;
     height: 60%;

--- a/src/services/FilterService.js
+++ b/src/services/FilterService.js
@@ -92,8 +92,12 @@ export const getInitialFilter = (allNeighborhoods) => {
 export const dataMatchesFilter = (report, filter) => {
     const { data } = report;
     const parsedDate = new Date(data.timestamp);
-    // ok with species    
-    return (filter.carnivoreFilter.all.value || filter.carnivoreFilter[data.species].value || matchesOtherCarnivore(filter, data.species)) &&
+    // If the report doesn't have any of the necessary fields, don't display it.
+    if (!data.species || !data.neighborhood || !parsedDate || !data.confidence) {
+        return false;
+    }
+    // ok with species
+    return (filter.carnivoreFilter.all.value || (filter.carnivoreFilter[data.species] && filter.carnivoreFilter[data.species].value) || matchesOtherCarnivore(filter, data.species)) &&
     // ok with neighborhood
     (filter.neighborhoodFilter.all.value === true || (data.hasOwnProperty('neighborhood') && filter.neighborhoodFilter[data.neighborhood].value === true)) &&
     // ok with date


### PR DESCRIPTION
This solves the bug we were getting with the list not filtering properly, which was introduced in #39. The changes are twofold:
 - For any data, only display it/compare it against the filter if it has a species, neighborhood, confidence, and timestamp. This makes us a little more resilient against similar failures in the future. This also means that the data you're seeing on the page might be a little different, since many of the results we were displaying I either cleaned up in the process of trying to figure out what was going on, or doesn't contain all four of those components.
 -  In addition, any report that has a species, but that species doesn't match the filter, won't break our filter-checking function by trying to get `undefined.value`. 

I also moved the filter to match the desktop map filter position by replacing `top: 15%` with `bottom: 5%`. Looks like this:
![image](https://user-images.githubusercontent.com/12106730/59644113-63271f00-9120-11e9-9aed-a45683b1b6ec.png)
