### PR TITLE
Update Styling of Mobile Resources

### DIFF
--- a/src/components/Resources.js
+++ b/src/components/Resources.js
@@ -8,7 +8,7 @@ import {connect} from "react-redux";
 
 const styles = {
     allContentMobile: {
-        height: '100%',
+        minHeight: '100vh',
         overflow: 'scroll',
         position: 'relative',
         flexDirection: 'column',
@@ -16,7 +16,7 @@ const styles = {
     },
     allContentDesktop: {
         paddingTop: 50,
-        height: '100%',
+        minHeight: '100vh',
         overflow: 'scroll',
         position: 'relative',
         flexDirection: 'column',
@@ -132,6 +132,7 @@ class Resources extends Component {
                         <a href="mailto:seattlecarnivores@zoo.org">seattlecarnivores@zoo.org</a>
                     </div>
                 )}
+                <hr/>
             </div>
         );
     }

--- a/src/components/Resources.js
+++ b/src/components/Resources.js
@@ -7,12 +7,12 @@ import { getDisplayName } from '../services/ColorService';
 import {connect} from "react-redux";
 
 const styles = {
-    allContent: {
+    allContentMobile: {
         height: '100%',
         overflow: 'scroll',
         position: 'relative',
         flexDirection: 'column',
-        backgroundColor: 'white'
+        backgroundColor: '#F6F4F3'
     },
     allContentDesktop: {
         paddingTop: 50,
@@ -23,8 +23,8 @@ const styles = {
         backgroundColor: 'white'
     },
     header: {
+        display: 'flex',
         flexDirection: 'row',
-        alignItems: 'center',
         justifyContent: 'space-between',
         position: 'sticky',
         top: 0,
@@ -32,25 +32,37 @@ const styles = {
         zIndex: 1
     },
     expandButton: {
+        margin:10,
         boxShadow: 'none',
         float: 'right',
         position: 'relative',
-        top: -8,
-        backgroundColor: '#93C838',
-        color: 'white'
+        '& svg': {
+            fontSize: 25,
+        },
+        width: 30,
+        height: 30
     },
     expandHeader: {
         margin: 16,
         display: 'flex',
-        justifyContent: 'space-between'
+        justifyContent: 'space-between',
     },
     headerTitle: {
-        alignText: 'left',
+        fontWeight: 'bold',
+        fontSize: 18,
+        lineHeight:'50px'
+
     },
     collapsible: {
-        margin: 16,
-        textAlign: 'left'
+        textAlign: 'left',
+        lineHeight: '2',
+        fontSize: 17
     },
+    body: {
+        textAlign: 'left',
+        margin: 16,
+    },
+
 };
 const speciesList = ['blackbear', 'bobcat', 'cougar', 'coyote', 'opossum',
     'raccoon', 'riverotter'];
@@ -71,9 +83,8 @@ class Resources extends Component {
         return <>
             <div className={classes.expandHeader}>
                 <span className={classes.headerTitle}>{headerTitle}</span>
-                <Fab
+                <Fab className={classes.expandButton}
                     onClick={onClick}
-                    size="small"
                     disableRipple={true}>
                     {expand ? <RemoveIcon /> : <AddIcon />}
                 </Fab>
@@ -81,6 +92,7 @@ class Resources extends Component {
             <Collapse in={expand} className={classes.collapsible}>
                 {child}
             </Collapse>
+
         </>
     };
 
@@ -93,10 +105,10 @@ class Resources extends Component {
         const {showTips, showProjectDescription, showContactUs} = this.state;
         const {classes, isMobile} = this.props;
         return(
-            <div className={isMobile? classes.allContent : classes.allContentDesktop}>
+            <div className={isMobile? classes.allContentMobile : classes.allContentDesktop}>
                 {/* Species Identification Tips */}
                 {this.getCollapse(classes, "Species Identification Tips", this.toggleShow('showTips'), showTips,
-                    <div>
+                    <div className={classes.body}>
                         {speciesList.map((type, idx) =>
                             <li key={idx}>
                                 <Link to={`/resources/${type}`}>{getDisplayName(type)}</Link>
@@ -108,7 +120,7 @@ class Resources extends Component {
 
                 {/* Seattle Urban Carnivore Project */}
                 {this.getCollapse(classes, "Seattle Urban Carnivore Project", this.toggleShow('showProjectDescription'), showProjectDescription,
-                    <div className={classes.headerTitle}>
+                    <div className={classes.body}>
                         <p>Seattle Spotter is part of the SeattleUrban Carnivore Project, a collaboration between the Seattle University and WoodlandPark Zoo</p>
                         <a href="https://www.zoo.org/otters">learn more</a>
                     </div>
@@ -118,12 +130,12 @@ class Resources extends Component {
 
                 {/* Contact Us */}
                 {this.getCollapse(classes, "Contact Us", this.toggleShow('showContactUs'), showContactUs,
-                    <div className={classes.headerTitle} >
+                    <div className={classes.body} >
                         <a href="mailto:seattlecarnivores@zoo.org">seattlecarnivores@zoo.org</a>
                     </div>
                 )}
-                <hr/>
             </div>
+
         );
     }
 }

--- a/src/components/Resources.js
+++ b/src/components/Resources.js
@@ -39,19 +39,19 @@ const styles = {
         '& svg': {
             fontSize: 25,
         },
-        width: 30,
+        width: 35,
         height: 30
     },
     expandHeader: {
         margin: 16,
         display: 'flex',
-        justifyContent: 'space-between',
+        justifyContent: 'space-between'
     },
     headerTitle: {
+        alignText: 'left',
         fontWeight: 'bold',
         fontSize: 18,
         lineHeight:'50px'
-
     },
     collapsible: {
         textAlign: 'left',
@@ -59,10 +59,9 @@ const styles = {
         fontSize: 17
     },
     body: {
-        textAlign: 'left',
         margin: 16,
+        textAlign: 'left'
     },
-
 };
 const speciesList = ['blackbear', 'bobcat', 'cougar', 'coyote', 'opossum',
     'raccoon', 'riverotter'];
@@ -92,7 +91,6 @@ class Resources extends Component {
             <Collapse in={expand} className={classes.collapsible}>
                 {child}
             </Collapse>
-
         </>
     };
 
@@ -135,7 +133,6 @@ class Resources extends Component {
                     </div>
                 )}
             </div>
-
         );
     }
 }


### PR DESCRIPTION
This PR updates the css of Resources page in Mobile view. Following are the updates:

1) Increased spacing between the animal listings
2) Align the titles vertically center between the div lines
3) Update the background color of the page to F6F4F3 to make it stand out from the bottom panel
4) Make the titles little bit bigger and bold compared to the text in the body
<img src="https://user-images.githubusercontent.com/42149840/59657707-5b826d00-9156-11e9-8907-b228422b469f.png" width=200/>


These updates are for mobile view. Desktop resources page will be updated after Holly sends in the updated mocks.