### PR TITLE
Media upload UX improvements

### DIFF
--- a/src/components/MediaDisplay.js
+++ b/src/components/MediaDisplay.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import CheckCircleOutlinedIcon from '@material-ui/icons/CheckCircleOutlined';
+import CancelOutlinedIcon from '@material-ui/icons/CancelOutlined';
+import { withStyles } from '@material-ui/core';
+import CircularProgress from '@material-ui/core/CircularProgress';
+
+const styles = {
+  thumbnail: {
+    height: 100,
+    width: 100,
+    objectFit: 'contain',
+    margin: 4,
+  },
+  filesDisplay: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+  },
+  iconTextSpan: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  green: {
+    color: '#93C838'
+  },
+  filesSelectedHeader: {
+    color: '#3278BE',
+    marginTop: 16,
+    marginBottom: 16,
+  },
+  allContent: {
+    margin: 16
+  },
+  icon: {
+    marginRight: '8px'
+  }
+};
+
+const MediaDisplay = (props) => {
+  const { filesOnDeck, uploading, uploadedFiles, removeFiles, classes } = props;
+  return <div className={classes.allContent}>
+    {filesOnDeck && filesOnDeck.length > 0 && !uploading ?
+      <div>
+        <div className={classes.filesDisplay}>
+          {filesOnDeck.map((file, ind) =>
+            <div key={ind}>
+                <img className={classes.thumbnail}
+                     alt={'Uploaded File'}
+                     src={URL.createObjectURL(file)}/>
+            </div>
+          )}
+        </div>
+        <div className={classes.filesSelectedHeader}><strong>Files selected</strong></div>
+        <span onClick={removeFiles} className={classes.iconTextSpan}><CancelOutlinedIcon fontSize='small' className={classes.icon}/> Remove files</span>
+      </div>
+      : null}
+
+    {filesOnDeck && filesOnDeck.length > 0 && uploading ?
+      <CircularProgress/>
+      : null}
+    {uploadedFiles && uploadedFiles.length > 0 ?
+      <span className={`${classes.iconTextSpan} ${classes.green}`}><CheckCircleOutlinedIcon/>{uploadedFiles.length} file(s) uploaded</span>
+      : null}
+  </div>
+};
+
+export default withStyles(styles)(MediaDisplay);

--- a/src/components/MediaDisplay.js
+++ b/src/components/MediaDisplay.js
@@ -60,7 +60,7 @@ const MediaDisplay = (props) => {
       <CircularProgress/>
       : null}
     {uploadedFiles && uploadedFiles.length > 0 ?
-      <span className={`${classes.iconTextSpan} ${classes.green}`}><CheckCircleOutlinedIcon/>{uploadedFiles.length} file(s) uploaded</span>
+      <span className={`${classes.iconTextSpan} ${classes.green}`}><CheckCircleOutlinedIcon fontSize='small' className={classes.icon}/>{uploadedFiles.length} file(s) uploaded</span>
       : null}
   </div>
 };

--- a/src/components/Uploader.js
+++ b/src/components/Uploader.js
@@ -13,11 +13,7 @@ class Uploader extends Component {
     const { target: { files } } = e;
     const { getMedia } = this.props;
     const filesToStore = [];
-
-    for (let key in files) {
-      let file = files[key];
-      filesToStore.push(file);
-    }
+    Array.from(files).forEach(file => filesToStore.push(file));
 
     getMedia(filesToStore, this.fileUploader);
 


### PR DESCRIPTION
This makes some improvements to the experience as users upload media to their sightings.

I also fixed a bug where two extra entries were being appended to the end of the files, and confirmed that uploading still worked.

It looks like this: 

No upload button when no media is ready to be uploaded: 
![image](https://user-images.githubusercontent.com/12106730/59723033-228bdc00-91da-11e9-8524-c0ee6fdbce9d.png)
Previews, remove files, and "confirm upload" which actually sends the media to firebase:
![image](https://user-images.githubusercontent.com/12106730/59723061-39cac980-91da-11e9-9c96-78a87bf0226f.png)
Loading spinner as the files are loaded into firebase:
![image](https://user-images.githubusercontent.com/12106730/59723190-9332f880-91da-11e9-94fb-06bc7c906f3b.png)
Confirmation that files were actually uploaded: 
![image](https://user-images.githubusercontent.com/12106730/59723296-03da1500-91db-11e9-9c24-cdbd7b12c91c.png)

