### PR TITLE
Update FormMap on Mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -468,12 +468,7 @@ padding: 0;
     text-align: center;
 }
 
-.hidden {
-    display: none;
-    position: relative
-}
-
-.initial {
+.hiddenDiv {
     display: none;
     position: relative
 }

--- a/src/App.css
+++ b/src/App.css
@@ -456,4 +456,25 @@ padding: 0;
     text-transform: capitalize;
 }
 
+.interactiveMap {
+    height: 200px;
+    width: 250px;
+}
+
+.interactiveMapContainer {
+    height: 500px;
+    weight: 500px;
+    align-items: center;
+    text-align: center;
+}
+
+.hidden {
+    display: none;
+    position: relative
+}
+
+.initial {
+    display: none;
+    position: relative
+}
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -387,16 +387,6 @@ class Form extends Component {
             </div>
             {neighborhood ? <p style={{alignText: 'center'}}>{neighborhood}</p> : null}
           </div>
-
-          {/*<div className={this.state.finalMap ? '' : 'hiddenDiv'}>*/}
-            {/*<StaticFormMap classes={classes} passMapCoordinates={this.getMapCoordinates}*/}
-                           {/*centerLng={mapLng} centerLat={mapLat}/>*/}
-            {/*<div className={classes.addButtonContainer}>*/}
-              {/*<Button size="small" color="primary" variant="contained"*/}
-                      {/*onClick={() => this.setState({addMode: true})}>EDIT LOCATION</Button>*/}
-            {/*</div>*/}
-            {/*{neighborhood ? <p style={{alignText: 'center'}}>{neighborhood}</p> : null}*/}
-          {/*</div>*/}
         </div> :
         <div className="formItem">
           <h4>Identify the location of your sighting</h4>

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -16,16 +16,14 @@ import LoadingOverlay from 'react-loading-overlay';
 
 import MediaUpload from './MediaUpload';
 import FormMap from './FormMap';
+import StaticFormMap from './StaticFormMap'
 import NeighborhoodService from '../services/NeighborhoodService';
 import {Collapse, Fab, withStyles} from "@material-ui/core";
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 import { Carousel } from 'react-responsive-carousel';
-import BlackBear from "../assets/SpeciesCards/blackbear.png";
 import Coyote from "../assets/SpeciesCards/coyote.png";
 import Bobcat from "../assets/SpeciesCards/bobcat.png";
-import Cougar from "../assets/SpeciesCards/cougar.png";
 import Opossum from "../assets/SpeciesCards/opossum.png";
-import RiverOtter from "../assets/SpeciesCards/riverotter.png";
 import Raccoon from "../assets/SpeciesCards/raccoon.png";
 import Info from '@material-ui/icons/InfoOutlined';
 import {connect} from "react-redux";
@@ -130,6 +128,21 @@ const styles = {
     position: 'relative',
     paddingLeft: 35,
     paddingRight: 35,
+  },
+  addButtonContainer: {
+    zIndex: 99,
+    position: 'absolute',
+    left: '34%',
+    top: '15%'
+  },
+  doneButtonContainer: {
+    zIndex: 99,
+    position: 'absolute',
+    left: '40%'
+  },
+  staticMap: {
+    position: 'absolute',
+    zIndex: 99
   }
 };
 
@@ -171,7 +184,11 @@ class Form extends Component {
     showAnimalBehavior: false,
     showContactInformation: false,
     showCarousel: false,
-    carouselImageIndex:0
+    carouselImageIndex:0,
+    editMode: false,
+    addMode: false,
+    initialMap: true,
+    finalMap: false
   };
 
   constructor(props) {
@@ -341,10 +358,57 @@ class Form extends Component {
         return <FormInfoDialog
           open={true}
           onClose={this.handleClose}
-          message={THANKS_FOR_SUBMITTING}/>
+          message={THANKS_FOR_SUBMITTING}/>;
       default:
         return null;
     }
+  };
+
+  showInteractiveMap = (classes,neighborhood,mapLng,mapLat ) => {
+    return (
+        <div className="formItem">
+          <p> Drag the point on the map to mark your sighting</p>
+          <FormMap passMapCoordinates={this.getMapCoordinates}
+                   centerLng={mapLng} centerLat={mapLat} className="interactiveMap"/>
+          {neighborhood ? <p style={{alignText: 'center'}}>{neighborhood}</p> : null}
+          <div className={classes.doneButtonContainer}>
+            <Button size="small" color="primary" variant="contained" onClick={() => this.setState({addMode: false, editMode: true, initialMap: false, finalMap: true})}
+            > DONE </Button>
+          </div>
+        </div>
+    )
+  };
+  renderMap = (classes, isMobile, neighborhood, mapLng, mapLat) => {
+    return isMobile ?
+        <div className="formItem">
+          <h4>Identify the location of your sighting</h4>
+          <p> Drag the point on the map to mark your sighting</p>
+          <div className={this.state.initialMap ? '' : 'initial'}>
+            <StaticFormMap passMapCoordinates={this.getMapCoordinates}
+                           centerLng={mapLng} centerLat={mapLat} />
+            <div className={classes.addButtonContainer}>
+              <Button size="small" color="primary" variant="contained"
+                      onClick={() => this.setState({addMode: true})}>ADD LOCATION</Button>
+            </div>
+          </div>
+
+          <div className={this.state.finalMap ? '' : 'hidden'}>
+            <StaticFormMap classes={classes} passMapCoordinates={this.getMapCoordinates}
+                           centerLng={mapLng} centerLat={mapLat}/>
+            <div className={classes.addButtonContainer}>
+              <Button size="small" color="primary" variant="contained"
+                      onClick={() => this.setState({addMode: true})}>EDIT LOCATION</Button>
+            </div>
+            {neighborhood ? <p style={{alignText: 'center'}}>{neighborhood}</p> : null}
+          </div>
+        </div> :
+        <div className="formItem">
+          <h4>Identify the location of your sighting</h4>
+          <p> Drag the point on the map to mark your sighting</p>
+          <FormMap passMapCoordinates={this.getMapCoordinates}
+                   centerLng={mapLng} centerLat={mapLat}/>
+          {neighborhood ? <p>{neighborhood}</p> : null}
+        </div>
   };
 
   render() {
@@ -353,7 +417,7 @@ class Form extends Component {
       numberOfYoungSpecies, numberOfAdults, numberOfChildren, reaction, reactionDescription, numberOfDogs, dogSize,
       onLeash, animalBehavior, animalEating, vocalization, vocalizationDesc, carnivoreResponse, carnivoreConflict,
       conflictDesc, contactName, contactEmail, contactPhone, generalComments, mediaPaths, submitting,
-      neighborhood, dialogMode, showObserverDetails, showAnimalBehavior, showContactInformation
+      neighborhood, dialogMode, showObserverDetails, showAnimalBehavior, showContactInformation, addMode
     } = this.state;
     const {classes, isMobile} = this.props;
     return (
@@ -374,14 +438,17 @@ class Form extends Component {
               timeCaption="time"
             />
           </div>
-
+          {this.renderMap(classes, isMobile,neighborhood, mapLng, mapLat)}
           <div className="formItem">
-            <h4>Identify the location of your sighting</h4>
-            <p> Drag the point on the map to mark your sighting</p>
-
-            <FormMap passMapCoordinates={this.getMapCoordinates}
-                     centerLng={mapLng} centerLat={mapLat}/>
-            {neighborhood ? <p>{neighborhood}</p> : null}
+            <Dialog
+                open={addMode}
+            >
+              <DialogContent className="interactiveMapContainer" >
+                <div >
+                  {this.showInteractiveMap(classes,neighborhood,mapLng,mapLat)}
+                </div>
+              </DialogContent>
+            </Dialog>
           </div>
 
           {/*Image*/}

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -21,10 +21,6 @@ import NeighborhoodService from '../services/NeighborhoodService';
 import {Collapse, Fab, withStyles} from "@material-ui/core";
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 import { Carousel } from 'react-responsive-carousel';
-import Coyote from "../assets/SpeciesCards/coyote.png";
-import Bobcat from "../assets/SpeciesCards/bobcat.png";
-import Opossum from "../assets/SpeciesCards/opossum.png";
-import Raccoon from "../assets/SpeciesCards/raccoon.png";
 import Info from '@material-ui/icons/InfoOutlined';
 import {connect} from "react-redux";
 
@@ -383,7 +379,7 @@ class Form extends Component {
         <div className="formItem">
           <h4>Identify the location of your sighting</h4>
           <p> Drag the point on the map to mark your sighting</p>
-          <div className={this.state.initialMap ? '' : 'initial'}>
+          <div className={this.state.initialMap ? '' : 'hiddenDiv'}>
             <StaticFormMap passMapCoordinates={this.getMapCoordinates}
                            centerLng={mapLng} centerLat={mapLat} />
             <div className={classes.addButtonContainer}>
@@ -392,7 +388,7 @@ class Form extends Component {
             </div>
           </div>
 
-          <div className={this.state.finalMap ? '' : 'hidden'}>
+          <div className={this.state.finalMap ? '' : 'hiddenDiv'}>
             <StaticFormMap classes={classes} passMapCoordinates={this.getMapCoordinates}
                            centerLng={mapLng} centerLat={mapLat}/>
             <div className={classes.addButtonContainer}>

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -184,7 +184,7 @@ class Form extends Component {
     carouselImageIndex:0,
     editMode: false,
     addMode: false,
-    finalMap: true
+    finalMap: true,
     uploading: false
   };
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -126,7 +126,7 @@ const styles = {
     paddingRight: 35,
   },
   addButtonContainer: {
-    zIndex: 99,
+    zIndex: 999,
     position: 'absolute',
     left: '34%',
     top: '15%'
@@ -183,8 +183,7 @@ class Form extends Component {
     carouselImageIndex:0,
     editMode: false,
     addMode: false,
-    initialMap: true,
-    finalMap: false
+    finalMap: true
   };
 
   constructor(props) {
@@ -368,7 +367,7 @@ class Form extends Component {
                    centerLng={mapLng} centerLat={mapLat} className="interactiveMap"/>
           {neighborhood ? <p style={{alignText: 'center'}}>{neighborhood}</p> : null}
           <div className={classes.doneButtonContainer}>
-            <Button size="small" color="primary" variant="contained" onClick={() => this.setState({addMode: false, editMode: true, initialMap: false, finalMap: true})}
+            <Button size="small" color="primary" variant="contained" onClick={() => this.setState({ editMode: true, finalMap: true, addMode: false})}
             > DONE </Button>
           </div>
         </div>
@@ -379,24 +378,25 @@ class Form extends Component {
         <div className="formItem">
           <h4>Identify the location of your sighting</h4>
           <p> Drag the point on the map to mark your sighting</p>
-          <div className={this.state.initialMap ? '' : 'hiddenDiv'}>
+          <div className={this.state.finalMap ? '' : 'hiddenDiv'}>
             <StaticFormMap passMapCoordinates={this.getMapCoordinates}
                            centerLng={mapLng} centerLat={mapLat} />
-            <div className={classes.addButtonContainer}>
-              <Button size="small" color="primary" variant="contained"
-                      onClick={() => this.setState({addMode: true})}>ADD LOCATION</Button>
-            </div>
-          </div>
-
-          <div className={this.state.finalMap ? '' : 'hiddenDiv'}>
-            <StaticFormMap classes={classes} passMapCoordinates={this.getMapCoordinates}
-                           centerLng={mapLng} centerLat={mapLat}/>
             <div className={classes.addButtonContainer}>
               <Button size="small" color="primary" variant="contained"
                       onClick={() => this.setState({addMode: true})}>EDIT LOCATION</Button>
             </div>
             {neighborhood ? <p style={{alignText: 'center'}}>{neighborhood}</p> : null}
           </div>
+
+          {/*<div className={this.state.finalMap ? '' : 'hiddenDiv'}>*/}
+            {/*<StaticFormMap classes={classes} passMapCoordinates={this.getMapCoordinates}*/}
+                           {/*centerLng={mapLng} centerLat={mapLat}/>*/}
+            {/*<div className={classes.addButtonContainer}>*/}
+              {/*<Button size="small" color="primary" variant="contained"*/}
+                      {/*onClick={() => this.setState({addMode: true})}>EDIT LOCATION</Button>*/}
+            {/*</div>*/}
+            {/*{neighborhood ? <p style={{alignText: 'center'}}>{neighborhood}</p> : null}*/}
+          {/*</div>*/}
         </div> :
         <div className="formItem">
           <h4>Identify the location of your sighting</h4>

--- a/src/components/FormMap.js
+++ b/src/components/FormMap.js
@@ -17,13 +17,11 @@ class FormMap extends Component {
     const { passMapCoordinates } = this.props;
     const lng = e.lngLat.lng;
     const lat = e.lngLat.lat;
-
     passMapCoordinates({ lng, lat });
   };
 
   render() {
     const { centerLng, centerLat } = this.props;
-
     return (
       <div>
         <Map style="mapbox://styles/mapbox/streets-v9"
@@ -43,8 +41,6 @@ class FormMap extends Component {
                      onDragEnd={e => this.onDragEnd(e)}/>
           </Layer>
         </Map>
-
-
       </div>
     );
   }

--- a/src/components/MapView.js
+++ b/src/components/MapView.js
@@ -54,7 +54,6 @@ const styles = {
         left: '95%',
         position: 'fixed'
     }
-
 };
 class MapView extends Component {
     state = {

--- a/src/components/StaticFormMap.js
+++ b/src/components/StaticFormMap.js
@@ -8,7 +8,6 @@ const StaticMap = ReactMapboxGl({
 });
 
 class StaticFormMap extends Component {
-
     render() {
         const { centerLng, centerLat} = this.props;
         return (

--- a/src/components/StaticFormMap.js
+++ b/src/components/StaticFormMap.js
@@ -1,0 +1,36 @@
+import React, { Component } from 'react';
+import ReactMapboxGl, { Layer, Feature } from 'react-mapbox-gl';
+
+const StaticMap = ReactMapboxGl({
+    accessToken: process.env.REACT_APP_MAPBOX_TOKEN,
+    dragPan: false,
+    interactive: false
+});
+
+class StaticFormMap extends Component {
+
+    render() {
+        const { centerLng, centerLat} = this.props;
+        return (
+            <StaticMap style="mapbox://styles/mapbox/streets-v9"
+                 center={{ lng: centerLng, lat: centerLat }}
+                 className="formMap"
+            >
+                <div>
+                    <Layer type="circle"
+                           id="marker"
+                           paint={{
+                               'circle-color': '#ff5200',
+                               'circle-stroke-width': 1,
+                               'circle-stroke-opacity': 1,
+                               'circle-radius': 10
+                           }}>
+                        <Feature coordinates={[centerLng, centerLat]} />
+                    </Layer>
+                </div>
+            </StaticMap>
+        );
+    }
+}
+
+export default StaticFormMap;


### PR DESCRIPTION
This PR updates the design of the map element in the form on mobile. Currently both the desktop and mobile has the same design for form map that allows to pick a location of sighting.  Since drag and drop of pin on mobile sometimes results in dragging the pan, following updates have been made on mobile:
1) Form opens up with a non interactive or static map with an "Add Location" button.
<img src="https://user-images.githubusercontent.com/42149840/59741212-2f7eee80-921f-11e9-808e-4c5103235bb3.png" width=250 height=400/>
2) On clicking the "Add Location" button, an interactive map opens up where the user can drag and drop pin to select location. The corresponding neighborhood gets displayed below the map. On clicking the "Done" button, the location gets updated on the map in the form. 
<img src="https://user-images.githubusercontent.com/42149840/59741386-b8962580-921f-11e9-92e5-fe5b4a2d063f.png" width=250 height=400/>
3) The map is non interactive with the marker on the selected location. Neighborhood is displayed below the map. The "Edit location" button can be used to update the selection.
<img src="https://user-images.githubusercontent.com/42149840/59741453-e67b6a00-921f-11e9-89e7-e7ac96a7b711.png" width=250 height=400/>



