### PR TITLE
Fix EditButton Visibility

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -127,7 +127,6 @@ const styles = {
     paddingRight: 35,
   },
   addButtonContainer: {
-    zIndex: 999,
     position: 'absolute',
     left: '34%',
     top: '15%'


### PR DESCRIPTION
This is a quick fix to hide edit button when the DatePicker is selected.
<img src="https://user-images.githubusercontent.com/42149840/59879749-4aa54780-9360-11e9-9982-81caa5d94094.png" width=200/>

