### PR TITLE
Automatically scroll to top of page and fix headers on scroll

### DIFF
--- a/src/components/DesktopHeader.js
+++ b/src/components/DesktopHeader.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
-
+import Sticky from 'react-sticky-fill';
 import AppBar from '@material-ui/core/AppBar';
 
 import '../App.css';
@@ -12,7 +12,7 @@ class DesktopHeader extends Component {
     const { history } = this.props;
 
     return (
-      <div style={{ position: 'sticky', top: 0, width: '100%', zIndex: 100 }}>
+      <Sticky style={{top: 0, width: '100%', zIndex: 100}}>
         <AppBar position="static" className="appBar">
           <div className="logo"/>
           <h1 className="headerTitle" onClick={() => history.push('/')} style={{ cursor: 'pointer' }}>
@@ -27,7 +27,7 @@ class DesktopHeader extends Component {
           </div>
 
         </AppBar>
-      </div>
+      </Sticky>
     );
   }
 }

--- a/src/components/MobileHeader.js
+++ b/src/components/MobileHeader.js
@@ -4,6 +4,7 @@ import { withStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Button from '@material-ui/core/Button';
 import SwipeableDrawer from '@material-ui/core/SwipeableDrawer/SwipeableDrawer';
+import Sticky from 'react-sticky-fill';
 
 import FilterDrawer from './FilterDrawer';
 
@@ -30,7 +31,7 @@ class MobileHeader extends Component {
     const { history, location, classes} = this.props;
 
     return (
-      <div style={{ position: 'sticky', top: 0, width: '100%', zIndex: 100 }}>
+      <Sticky style={{top: 0, width: '100%', zIndex: 100}}>
         <AppBar position="static" color="default">
           <div className="headerDiv">
             <h1 style={{ display: 'table-cell', cursor: 'pointer', marginLeft: 20}}
@@ -57,7 +58,7 @@ class MobileHeader extends Component {
             </SwipeableDrawer>
           </div>
         </AppBar>
-      </div>
+      </Sticky>
     );
   }
 }

--- a/src/components/ScrollToTop.js
+++ b/src/components/ScrollToTop.js
@@ -1,0 +1,20 @@
+import React, {Component} from 'react';
+import { withRouter } from 'react-router-dom';
+
+/**
+ * Thanks to https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/guides/scroll-restoration.md
+ * for the hints on automatically scrolling to the top of a page on navigation.
+ */
+class ScrollToTop extends Component {
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    if (this.props.location.pathname !== prevProps.location.pathname) {
+      window.scrollTo(0,0);
+    }
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+export default withRouter(ScrollToTop);

--- a/src/index.js
+++ b/src/index.js
@@ -7,14 +7,17 @@ import { store } from './store/index';
 
 import './index.css';
 import App from './App';
+import ScrollToTop from "./components/ScrollToTop";
 
 ReactDOM.render((
     <BrowserRouter basename="urban-carnivore-spotter">
-      <Provider store={store}>
-        <FirebaseContext.Provider value={new Firebase()}>
-          <App/>
-        </FirebaseContext.Provider>
-      </Provider>
+      <ScrollToTop>
+        <Provider store={store}>
+          <FirebaseContext.Provider value={new Firebase()}>
+            <App/>
+          </FirebaseContext.Provider>
+        </Provider>
+      </ScrollToTop>
     </BrowserRouter>),
   document.getElementById('root'));
 


### PR DESCRIPTION
Now, when a user navigates to a new page, they automatically scroll to the top of the page. This prevents some issues we were having with the navigation disappearing on certain pages.

In addition, I've added the `<Sticky />` polyfill to the desktop and mobile headers so they stay visible while scrolling on Safari. For example:

Before, partially scrolled down on the list view:
![image](https://user-images.githubusercontent.com/12106730/60044764-f0fe8f00-9677-11e9-9aee-aa073375725a.png)
After, partially scrolled down on the list view:
![image](https://user-images.githubusercontent.com/12106730/60044819-14293e80-9678-11e9-8c17-2d6901f784eb.png)
