### PR TITLE
Fix a issue with displaying time

### DIFF
--- a/src/components/ListCard.js
+++ b/src/components/ListCard.js
@@ -6,6 +6,7 @@ import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 import {Link} from "react-router-dom";
 import Placeholder from '../assets/placeholder.svg';
+import { firebaseTimeToDateTimeString } from "../services/TimeService";
 
 const styles = theme => ({
   info: {
@@ -20,18 +21,6 @@ const styles = theme => ({
   }
 });
 
-/**
- * Get a string for a timestamp in the format that Cloud Firestore sends us.
- * Time should be an object with _nanoseconds and _seconds as fields.
- */
-const timeToString = time => {
-  if (time) {
-    const date = new Date(time);
-    return `${date.toDateString()} ${date.getHours()}:${date.getMinutes()}`;
-  }
-  return 'Unknown Time';
-};
-
 const ListCard = props => {
   const { classes, report } = props;
   return <Card className="card">
@@ -41,7 +30,7 @@ const ListCard = props => {
       />
       <CardContent className={classes.info}>
         <Typography variant={'h5'}>{report.data.species.toUpperCase()}</Typography>
-        <Typography variant={'subtitle1'}>{timeToString(report.data.timestamp)}</Typography>
+        <Typography variant={'subtitle1'}>{firebaseTimeToDateTimeString(report.data.timestamp)}</Typography>
         <Typography style={{ color: 'grey' }}>{report.data.neighborhood ? report.data.neighborhood : "Unknown"}</Typography>
         <li>
           <Link to={`/reports/${report.id}`}>See Report</Link>

--- a/src/components/PointTooltip.js
+++ b/src/components/PointTooltip.js
@@ -3,11 +3,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { withRouter } from 'react-router-dom';
 import {KeyboardArrowRight} from "@material-ui/icons";
 import Placeholder from '../assets/placeholder.svg';
-
-const timeToString = time => {
-    const date = new Date(time);
-    return `${date.toDateString()} ${date.getHours()}:${date.getMinutes()}`;
-};
+import { firebaseTimeToDateTimeString } from "../services/TimeService";
 
 const styles = {
     allContent: {
@@ -38,7 +34,7 @@ class PointTooltip extends Component {
             <div className={classes.info}>
                 <div><strong>{report.data.species}</strong></div>
                 <div><strong>Date & Time:</strong></div>
-                <div>{timeToString(report.data.timestamp)}</div>
+                <div>{firebaseTimeToDateTimeString(report.data.timestamp)}</div>
                 <div><strong>Location:</strong> {report.data.neighborhood}</div>
             </div>
             <div className={classes.reportLink} onClick={() => history.push(`/reports/${report.id}`)}>

--- a/src/components/ReportViewer.js
+++ b/src/components/ReportViewer.js
@@ -7,6 +7,8 @@ import Card from "@material-ui/core/Card";
 import { CircularProgress, Toolbar } from "@material-ui/core";
 import { KeyboardArrowLeft } from "@material-ui/icons";
 
+import {jsDateToTimeString} from "../services/TimeService";
+
 import ImageGallery from 'react-image-gallery';
 
 const getReport = 'https://us-central1-seattlecarnivores-edca2.cloudfunctions.net/getReport';
@@ -57,7 +59,7 @@ class ReportViewer extends Component {
                           showThumbnails={false} showVideo={true}/> : null}
           <div style={{ backgroundColor: 'white', textAlign: 'left', paddingLeft: '30px'}}>
             <p><strong>Date:</strong> {new Date(report.timestamp).toDateString()}</p>
-            <p><strong>Time of Sighting:</strong> {date.getHours()}:{date.getMinutes()}</p>
+            <p><strong>Time of Sighting:</strong> {jsDateToTimeString(report.timestamp)}</p>
             <p><strong>Neighborhood:</strong> {report.neighborhood}</p>
             <p><strong>Confidence:</strong> {report.confidence}</p>
             <p style={{lineHeight:'.5'}}><strong>Number of Species:</strong></p>

--- a/src/services/TimeService.js
+++ b/src/services/TimeService.js
@@ -1,0 +1,26 @@
+// Functions that relate to the Firebase time format
+/**
+ * Get a string for a timestamp in the format that Cloud Firestore sends us.
+ * Time should be an object with _nanoseconds and _seconds as fields.
+ */
+export const firebaseTimeToDateTimeString = (time) => {
+  if (time) {
+    const date = new Date(time);
+    return `${date.toDateString()} ${jsDateToTimeString(date)}`;
+  }
+  return 'Unknown Time';
+};
+
+/**
+ * Given a JS Date() object, return a string representing the time of day.
+ * @param time - a JS Date() object
+ */
+export const jsDateToTimeString = (time) => {
+  if (time) {
+    const date = new Date(time);
+    const hours = date.getHours().toString().padStart(2, '0');
+    const minutes = date.getMinutes().toString().padStart(2, '0');
+    return `${hours} ${minutes}`;
+  }
+  return 'Unknown Time';
+};

--- a/src/services/TimeService.js
+++ b/src/services/TimeService.js
@@ -20,7 +20,7 @@ export const jsDateToTimeString = (time) => {
     const date = new Date(time);
     const hours = date.getHours().toString().padStart(2, '0');
     const minutes = date.getMinutes().toString().padStart(2, '0');
-    return `${hours} ${minutes}`;
+    return `${hours}:${minutes}`;
   }
   return 'Unknown Time';
 };

--- a/src/services/TimeService.js
+++ b/src/services/TimeService.js
@@ -18,7 +18,7 @@ export const firebaseTimeToDateTimeString = (time) => {
 export const jsDateToTimeString = (time) => {
   if (time) {
     const date = new Date(time);
-    const hours = date.getHours().toString().padStart(2, '0');
+    const hours = date.getHours().toString();
     const minutes = date.getMinutes().toString().padStart(2, '0');
     return `${hours}:${minutes}`;
   }


### PR DESCRIPTION
We were displaying hours/minutes by printing the date.getHours() followed by date.getMinutes(), but we weren't padding the minutes. So 12:03 would display as 12:3, which isn't great.

This PR consolidates the logic to display time (which was spread out/repeated in a couple places), and pads the minutes so that the display looks right. We don't pad the hours, since 3:03 looks right (but 03:03 looks a little funny). Somewhere down the line we could look at doing AM/PM as well, but I decided to leave it in 24-hour time for now.

Before:
![image](https://user-images.githubusercontent.com/12106730/60224814-edfecc80-9838-11e9-88ba-9234382d57c3.png)
After:
![image](https://user-images.githubusercontent.com/12106730/60224821-fa832500-9838-11e9-9f77-6a77a2461100.png)
