### PR TITLE
Update sizing of species carousel to work better for small devices

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -106,8 +106,10 @@ const styles = {
     height: 500,
   },
   carouselMobile: {
-    width: 320,
-    height: 400,
+    minWidth: 160,
+    minHeight: 200,
+    maxWidth: 320,
+    maxHeight: 400
   },
   mobileImage: {
     width: 300,

--- a/src/components/ResourceCard.js
+++ b/src/components/ResourceCard.js
@@ -9,8 +9,10 @@ import {getImageBySpecies, getDataForSpecies} from "../services/SpeciesService";
 
 const styles = {
     mobileImage: {
-        width: 400,
-        height: 500,
+        minWidth: 200,
+        minHeight: 250,
+        maxWidth: 400,
+        maxHeight: 500,
         paddingLeft: 0,
         paddingRight: 20
     },

--- a/src/components/SpeciesCardMobile.js
+++ b/src/components/SpeciesCardMobile.js
@@ -34,7 +34,8 @@ const styles = {
     margin: '32px 0px 32px 0px'
   },
   allContent: {
-    backgroundColor: '#F5F5F5'
+    backgroundColor: '#F5F5F5',
+    height: '100%'
   },
   labImage: {
     margin: 16,


### PR DESCRIPTION
This fixes a couple things about the species carousel so that it works better on small devices:

 - allows the carousel to shrink so that it doesn't require scrolling (which gets easily confused with swiping) on mobile devices with width around 350px:
![image](https://user-images.githubusercontent.com/12106730/60460442-a097ac00-9bf8-11e9-8835-d715a8e8b72f.png)

 - scrolling to the bottom of the slide doesn't reveal a black box anymore:
![image](https://user-images.githubusercontent.com/12106730/60460467-b1e0b880-9bf8-11e9-8b2d-9391613977eb.png)
 