### PR TITLE
Map zoom-out fix

### DIFF
--- a/src/components/MapView.js
+++ b/src/components/MapView.js
@@ -118,8 +118,10 @@ class MapView extends Component {
             .catch(error => error);
     }
 
-    onMoveEnd = e => {
-        let center = e.getCenter();
+    onMoveEnd = (map) => {
+        const center = map.getCenter();
+        const zoom = map.getZoom();
+        this.setState({viewport: {center: [center.lng, center.lat], zoom: [zoom]}});
         const url = getReports+"?mapLat="+center.lat+"&mapLng="+center.lng;
         axios.get(url)
             .then(reports => {
@@ -180,14 +182,7 @@ class MapView extends Component {
 
     render() {
         const {classes, isMobile, filter,history} = this.props;
-        const {reports,legend} = this.state;
-        if (!reports) {
-            return <Map2 style="mapbox://styles/mapbox/streets-v9"
-                         className="map"
-                         {...this.state.viewport}
-                         onMoveEnd={e => this.onMoveEnd(e)}
-            />
-        }
+        const {reports,legend,viewport} = this.state;
         return (
             <div className="mapContainer">
                 { !isMobile && <div className={classes.filterContainer}>
@@ -195,11 +190,12 @@ class MapView extends Component {
                 </div>}
                 <Map2 style="mapbox://styles/mapbox/streets-v9"
                       className="map"
-                      {...this.state.viewport}
+                      center={viewport.center}
+                      zoom={viewport.zoom}
                       onMoveEnd={e => this.onMoveEnd(e)}
                 >
                     {this.renderPopup()}
-                    {reports.filter(report => dataMatchesFilter(report, filter))
+                    {reports ? reports.filter(report => dataMatchesFilter(report, filter))
                         .map(report => (
                             <Layer type="circle"
                                 key ={report.id}
@@ -207,7 +203,7 @@ class MapView extends Component {
                                 <Feature  key ={report.id} coordinates={[report.data.mapLng, report.data.mapLat]}
                                         onClick={() => this.setState({popupInfo: report})}
                                 />
-                            </Layer>))}
+                            </Layer>)) : null}
                     <div>
                         <Fab className = {isMobile? classes.legendMobileContainer : classes.legendDesktopContainer} aria-label = "Legend"  size="small">
                             <Help  onClick = {() => this.setState({legend: true})}/>


### PR DESCRIPTION
This addresses a couple of small issues with the map rendering logic that was causing weird behavior when zoomed out. 

1. If `reports` are null, then a totally different map is rendered. This was causing the icon buttons and filter box to not render until the reports check in the first time. I pushed the `!reports` logic further into the render in order to resolve this.

2. The `viewport` state was never being updated. I added some logic in `onMoveEnd` to update the state so whenever we move the map, the viewport is correct. I think this change isn't actually necessary given that we're now only rendering one map, but now the `viewport` state variable makes more sense IMO.

Proof of the map at a zoomed-out level: 
![image](https://user-images.githubusercontent.com/12106730/60470734-71903300-9c16-11e9-8c3e-4373e8ec2d36.png)
