### PR TITLE
Italics and small typos

### DIFF
--- a/src/components/Resources.js
+++ b/src/components/Resources.js
@@ -123,7 +123,7 @@ class Resources extends Component {
                 {/* Seattle Urban Carnivore Project */}
                 {this.getCollapse(classes, "Seattle Urban Carnivore Project", this.toggleShow('showProjectDescription'), showProjectDescription,
                     <div className={classes.body}>
-                        <p>Seattle Carnivore Spotter is part of the Seattle Urban Carnivore Project, a collaboration between the Seattle University and Woodland Park Zoo</p>
+                        <p>Urban Carnivore Spotter is part of the Seattle Urban Carnivore Project, a collaboration between the Seattle University and Woodland Park Zoo</p>
                         <a href="https://www.zoo.org/otters">learn more</a>
                     </div>
 

--- a/src/components/Resources.js
+++ b/src/components/Resources.js
@@ -123,7 +123,7 @@ class Resources extends Component {
                 {/* Seattle Urban Carnivore Project */}
                 {this.getCollapse(classes, "Seattle Urban Carnivore Project", this.toggleShow('showProjectDescription'), showProjectDescription,
                     <div className={classes.body}>
-                        <p>Seattle Spotter is part of the SeattleUrban Carnivore Project, a collaboration between the Seattle University and WoodlandPark Zoo</p>
+                        <p>Seattle Carnivore Spotter is part of the Seattle Urban Carnivore Project, a collaboration between the Seattle University and Woodland Park Zoo</p>
                         <a href="https://www.zoo.org/otters">learn more</a>
                     </div>
 

--- a/src/components/ResourcesDesktop.js
+++ b/src/components/ResourcesDesktop.js
@@ -70,7 +70,7 @@ class ResourcesDesktop extends Component {
         <div>
           <h3 className={classes.header}>Seattle Urban Carnivore Project</h3>
           <div className={classes.content}>
-            <p>Seattle Spotter is part of the Seattle Urban Carnivore Project, a collaboration between the Seattle University and Woodland Park Zoo.</p>
+            <p>Seattle Carnivore Spotter is part of the Seattle Urban Carnivore Project, a collaboration between the Seattle University and Woodland Park Zoo.</p>
             <a href="https://www.zoo.org/otters">learn more</a>
           </div>
         </div>

--- a/src/components/ResourcesDesktop.js
+++ b/src/components/ResourcesDesktop.js
@@ -70,7 +70,7 @@ class ResourcesDesktop extends Component {
         <div>
           <h3 className={classes.header}>Seattle Urban Carnivore Project</h3>
           <div className={classes.content}>
-            <p>Seattle Carnivore Spotter is part of the Seattle Urban Carnivore Project, a collaboration between the Seattle University and Woodland Park Zoo.</p>
+            <p>Urban Carnivore Spotter is part of the Seattle Urban Carnivore Project, a collaboration between the Seattle University and Woodland Park Zoo.</p>
             <a href="https://www.zoo.org/otters">learn more</a>
           </div>
         </div>

--- a/src/components/SpeciesCardDesktop.js
+++ b/src/components/SpeciesCardDesktop.js
@@ -32,7 +32,7 @@ const SpeciesCardDesktop = (props) => {
     <div className={classes.headerAndImageContainer}>
       <div className={classes.headerContainer}>
         <h3 className={classes.speciesHeader}>{speciesName}</h3>
-        <h4 className={classes.speciesHeader}>({latinName})</h4>
+        <h4 className={classes.speciesHeader}>(<em>{latinName}</em>)</h4>
       </div>
       <img className={classes.image}
          src={imagePath}

--- a/src/components/SpeciesCardMobile.js
+++ b/src/components/SpeciesCardMobile.js
@@ -51,7 +51,7 @@ const SpeciesCardMobile = (props) => {
          alt={speciesName}/>
     <div className={classes.headerContainer}>
       <h3 className={classes.speciesHeader}>{speciesName}</h3>
-      <h4 className={classes.speciesHeader}>({latinName})</h4>
+      <h4 className={classes.speciesHeader}>(<em>{latinName}</em>)</h4>
     </div>
     <SpeciesCardInfo
       weight={weight}


### PR DESCRIPTION
Fixes a couple of typos and makes the scientific names italic. 

Italics & small fixes on the desktop resource page:
![image](https://user-images.githubusercontent.com/12106730/60928466-6ebebf00-a262-11e9-935a-5f744f2cf846.png)

Small fixes on the mobile resource page:
![image](https://user-images.githubusercontent.com/12106730/60928486-84cc7f80-a262-11e9-97f6-ffc19bbcdd28.png)

Italics on mobile cards:
![image](https://user-images.githubusercontent.com/12106730/60928501-92820500-a262-11e9-8df3-23dbcebf3be5.png)

I'm not sure if "Seattle Carnivore Spotter" is exactly right--happy to change it around :)

