### PR TITLE
Mobile form map improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8642,6 +8642,11 @@
         }
       }
     },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -17644,6 +17649,11 @@
         "moment": ">=1.6.0"
       }
     },
+    "react-node-resolver": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/react-node-resolver/-/react-node-resolver-2.0.1.tgz",
+      "integrity": "sha512-+PPy/FtAAo5wsLQYMlHkxJ3AMUGL33gpEIx/HBzS8OrcIfacRhGaNVWUJ8bhEbc64en+/bbCNTVZR+pkhqXEbA=="
+    },
     "react-onclickoutside": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.8.0.tgz",
@@ -17866,6 +17876,15 @@
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
           "integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg=="
         }
+      }
+    },
+    "react-scrolllock": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-scrolllock/-/react-scrolllock-4.0.1.tgz",
+      "integrity": "sha512-XWtRucd411402AfwnUyR0cZqN/beJy0NAygX92APzgeAhkHzpfWrsiakqKVIVqMNkgM8s2lIku/hzaFoTgw7Gw==",
+      "requires": {
+        "exenv": "^1.2.2",
+        "react-node-resolver": "^2.0.1"
       }
     },
     "react-sticky-fill": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
     "react-scripts": "^2.1.8",
+    "react-scrolllock": "^4.0.1",
     "react-sticky-fill": "^0.8.4",
     "react-swipeable-views": "^0.13.3",
     "react-swipeable-views-utils": "^0.13.3",

--- a/src/App.css
+++ b/src/App.css
@@ -172,7 +172,7 @@ Form Wizard Styles
 }
 
 .formMap {
-    height: 300px;
+    height: 100%;
 }
 
 .react-datepicker-wrapper > div > input {
@@ -462,7 +462,7 @@ padding: 0;
 }
 
 .interactiveMapContainer {
-    height: 500px;
+    height: calc(100vh - 150px);
     weight: 500px;
     align-items: center;
     text-align: center;
@@ -471,5 +471,9 @@ padding: 0;
 .hiddenDiv {
     display: none;
     position: relative
+}
+
+.constantHeightMapContainer {
+    height: 300px
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -462,7 +462,7 @@ padding: 0;
 }
 
 .interactiveMapContainer {
-    height: calc(100vh - 150px);
+    height: calc(100vh - 250px);
     weight: 500px;
     align-items: center;
     text-align: center;

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -389,7 +389,6 @@ class Form extends Component {
     return isMobile ?
         <div className="formItem">
           <h4>Identify the location of your sighting</h4>
-          <p> Drag the point on the map to mark your sighting</p>
           <div className={this.state.finalMap ? '' : 'hiddenDiv'}>
             <StaticFormMap passMapCoordinates={this.getMapCoordinates}
                            centerLng={mapLng} centerLat={mapLat} />

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -131,16 +131,20 @@ const styles = {
   addButtonContainer: {
     position: 'absolute',
     left: '34%',
-    top: '15%'
+    top: '15%',
+    zIndex: 100,
   },
   doneButtonContainer: {
-    zIndex: 99,
-    position: 'absolute',
-    left: '40%'
+    display: 'flex',
+    justifyContent: 'center',
   },
-  staticMap: {
-    position: 'absolute',
-    zIndex: 99
+  interactiveMapContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+  },
+  interactiveMapInnerContainer: {
+    flex: 1,
   }
 };
 
@@ -365,10 +369,12 @@ class Form extends Component {
 
   showInteractiveMap = (classes,neighborhood,mapLng,mapLat ) => {
     return (
-        <div className="formItem">
+        <div className={classes.interactiveMapContainer}>
           <p> Drag the point on the map to mark your sighting</p>
-          <FormMap passMapCoordinates={this.getMapCoordinates}
-                   centerLng={mapLng} centerLat={mapLat} className="interactiveMap"/>
+          <div className={classes.interactiveMapInnerContainer}>
+            <FormMap passMapCoordinates={this.getMapCoordinates}
+                     centerLng={mapLng} centerLat={mapLat} className="interactiveMap"/>
+          </div>
           {neighborhood ? <p style={{alignText: 'center'}}>{neighborhood}</p> : null}
           <div className={classes.doneButtonContainer}>
             <Button size="small" color="primary" variant="contained" onClick={() => this.setState({ editMode: true, finalMap: true, addMode: false})}
@@ -395,8 +401,10 @@ class Form extends Component {
         <div className="formItem">
           <h4>Identify the location of your sighting</h4>
           <p> Drag the point on the map to mark your sighting</p>
-          <FormMap passMapCoordinates={this.getMapCoordinates}
-                   centerLng={mapLng} centerLat={mapLat}/>
+          <div className={'constantHeightMapContainer'}>
+            <FormMap passMapCoordinates={this.getMapCoordinates}
+                     centerLng={mapLng} centerLat={mapLat}/>
+          </div>
           {neighborhood ? <p>{neighborhood}</p> : null}
         </div>
   };
@@ -433,11 +441,10 @@ class Form extends Component {
           <div className="formItem">
             <Dialog
                 open={addMode}
+                onClose={() => this.setState({addMode: false})}
             >
               <DialogContent className="interactiveMapContainer" >
-                <div >
-                  {this.showInteractiveMap(classes,neighborhood,mapLng,mapLat)}
-                </div>
+                {this.showInteractiveMap(classes,neighborhood,mapLng,mapLat)}
               </DialogContent>
             </Dialog>
           </div>

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -13,6 +13,7 @@ import DatePicker from 'react-datepicker';
 import { ValidatorForm, TextValidator, SelectValidator } from 'react-material-ui-form-validator';
 import 'react-datepicker/dist/react-datepicker.css';
 import LoadingOverlay from 'react-loading-overlay';
+import ScrollLock from 'react-scrolllock';
 
 import MediaUpload from './MediaUpload';
 import FormMap from './FormMap';
@@ -68,7 +69,6 @@ const styles = {
     display: 'flex',
     flexDirection: 'column',
     backgroundColor: 'white'
-
   },
   header: {
     display: 'flex',
@@ -369,6 +369,7 @@ class Form extends Component {
 
   showInteractiveMap = (classes,neighborhood,mapLng,mapLat ) => {
     return (
+      <ScrollLock>
         <div className={classes.interactiveMapContainer}>
           <p> Drag the point on the map to mark your sighting</p>
           <div className={classes.interactiveMapInnerContainer}>
@@ -381,6 +382,7 @@ class Form extends Component {
             > DONE </Button>
           </div>
         </div>
+      </ScrollLock>
     )
   };
   renderMap = (classes, isMobile, neighborhood, mapLng, mapLat) => {

--- a/src/components/FormMap.js
+++ b/src/components/FormMap.js
@@ -3,15 +3,10 @@ import ReactMapboxGl, { Layer, Feature } from 'react-mapbox-gl';
 
 const Map = ReactMapboxGl({
   accessToken: process.env.REACT_APP_MAPBOX_TOKEN,
-    dragPan: false
+  dragPan: false
 });
 
 class FormMap extends Component {
-
-  doNotPropagate = e => {
-      e.originalEvent.stopPropagation();
-      e.originalEvent.preventDefault();
-  };
 
   onDragEnd = e => {
     const { passMapCoordinates } = this.props;
@@ -27,7 +22,6 @@ class FormMap extends Component {
         <Map style="mapbox://styles/mapbox/streets-v9"
              center={{ lng: centerLng, lat: centerLat }}
              className="formMap"
-             onTouchMove={(map, e) => this.doNotPropagate(e)}
         >
           <Layer type="circle"
                  id="marker"

--- a/src/components/FormMap.js
+++ b/src/components/FormMap.js
@@ -18,7 +18,7 @@ class FormMap extends Component {
   render() {
     const { centerLng, centerLat } = this.props;
     return (
-      <div>
+      <div style={{height: '100%'}}>
         <Map style="mapbox://styles/mapbox/streets-v9"
              center={{ lng: centerLng, lat: centerLat }}
              className="formMap"

--- a/src/components/StaticFormMap.js
+++ b/src/components/StaticFormMap.js
@@ -11,6 +11,7 @@ class StaticFormMap extends Component {
     render() {
         const { centerLng, centerLat} = this.props;
         return (
+          <div className={"constantHeightMapContainer"}>
             <StaticMap style="mapbox://styles/mapbox/streets-v9"
                  center={{ lng: centerLng, lat: centerLat }}
                  className="formMap"
@@ -28,6 +29,7 @@ class StaticFormMap extends Component {
                     </Layer>
                 </div>
             </StaticMap>
+          </div>
         );
     }
 }


### PR DESCRIPTION
This PR improves the mobile form map by allowing pinch-zoom and fixing the dialog so a user doesn't ever need to scroll.

Dialog closed:
![image](https://user-images.githubusercontent.com/12106730/60933553-9ff5ba00-a277-11e9-9f74-6431195ff53e.png)

Dialog open:
![image](https://user-images.githubusercontent.com/12106730/60933563-ad12a900-a277-11e9-97ae-391905b2e499.png)

Desktop is unchanged:
![image](https://user-images.githubusercontent.com/12106730/60933593-cfa4c200-a277-11e9-8648-9cb2fc1eaabf.png)

In addition, clicking outside of the dialog now also closes it. 

This will be deployed at nachtm.github.io/urban-carnivore-spotter in a few minutes so you can play around with it live on mobile.