### PR TITLE
Update Map Marker Size

### DIFF
--- a/src/components/MapView.js
+++ b/src/components/MapView.js
@@ -200,8 +200,6 @@ class MapView extends Component {
                             <Layer type="circle"
                                 key ={report.id}
                                 paint={{'circle-color': getColorForSpecies(report.data.species.toLowerCase()),
-                                    'circle-stroke-width': 1,
-                                    'circle-stroke-opacity': .5,
                                     'circle-radius': 7}}>
                                 <Feature  key ={report.id} coordinates={[report.data.mapLng, report.data.mapLat]}
                                         onClick={() => this.setState({popupInfo: report})}

--- a/src/components/MapView.js
+++ b/src/components/MapView.js
@@ -199,7 +199,10 @@ class MapView extends Component {
                         .map(report => (
                             <Layer type="circle"
                                 key ={report.id}
-                                paint={{'circle-color': getColorForSpecies(report.data.species.toLowerCase())}}>
+                                paint={{'circle-color': getColorForSpecies(report.data.species.toLowerCase()),
+                                    'circle-stroke-width': 1,
+                                    'circle-stroke-opacity': .5,
+                                    'circle-radius': 7}}>
                                 <Feature  key ={report.id} coordinates={[report.data.mapLng, report.data.mapLat]}
                                         onClick={() => this.setState({popupInfo: report})}
                                 />


### PR DESCRIPTION
This PR increase the size of the feature markers on the main map for both desktop and mobile. I have updated the size to be 7 (the marker on the form has the size 10).
Before:
<img src="https://user-images.githubusercontent.com/42149840/61082907-56c07a00-a3df-11e9-9c53-c32d67856c75.png" width=300/>
After:
<img src="https://user-images.githubusercontent.com/42149840/61084834-c0428780-a3e3-11e9-8ab1-eacca07f3e58.png" width=300/>
