### PR TITLE
Prevent scrolling when dropdown is open on iOS Safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8642,6 +8642,11 @@
         }
       }
     },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -17644,6 +17649,11 @@
         "moment": ">=1.6.0"
       }
     },
+    "react-node-resolver": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/react-node-resolver/-/react-node-resolver-2.0.1.tgz",
+      "integrity": "sha512-+PPy/FtAAo5wsLQYMlHkxJ3AMUGL33gpEIx/HBzS8OrcIfacRhGaNVWUJ8bhEbc64en+/bbCNTVZR+pkhqXEbA=="
+    },
     "react-onclickoutside": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.8.0.tgz",
@@ -17866,6 +17876,15 @@
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
           "integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg=="
         }
+      }
+    },
+    "react-scrolllock": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-scrolllock/-/react-scrolllock-4.0.1.tgz",
+      "integrity": "sha512-XWtRucd411402AfwnUyR0cZqN/beJy0NAygX92APzgeAhkHzpfWrsiakqKVIVqMNkgM8s2lIku/hzaFoTgw7Gw==",
+      "requires": {
+        "exenv": "^1.2.2",
+        "react-node-resolver": "^2.0.1"
       }
     },
     "react-sticky-fill": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
     "react-scripts": "^2.1.8",
+    "react-scrolllock": "^4.0.1",
     "react-sticky-fill": "^0.8.4",
     "react-swipeable-views": "^0.13.3",
     "react-swipeable-views-utils": "^0.13.3",

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -521,9 +521,8 @@ class Form extends Component {
                 id: 'confidence',
               }}
             >
-              <ScrollLock>
-                {confidenceLevels.map((level, idx) => <MenuItem key={idx} value={level}>{level}</MenuItem>)}
-              </ScrollLock>
+              <ScrollLock />
+              {confidenceLevels.map((level, idx) => <MenuItem key={idx} value={level}>{level}</MenuItem>)}
             </SelectValidator>
           </div>
 
@@ -543,6 +542,7 @@ class Form extends Component {
                   id: 'numberOfAdultSpecies',
                 }}
               >
+                <ScrollLock />
                 {counts.map(idx => <MenuItem key={idx} value={idx}>{idx === 9 ? '9+' : idx.toString()}</MenuItem>)}
               </SelectValidator>
             </div>
@@ -559,6 +559,7 @@ class Form extends Component {
                 id: 'numberOfYoungSpecies',
               }}
             >
+              <ScrollLock />
               {counts.map(idx => <MenuItem key={idx} value={idx}>{idx === 9 ? '9+' : idx.toString()}</MenuItem>)}
             </SelectValidator>
           </div>
@@ -582,6 +583,7 @@ class Form extends Component {
                           id: 'numberOfAdults',
                         }}
                     >
+                      <ScrollLock />
                       {counts.map(idx => <MenuItem key={idx} value={idx}>{idx === 9 ? '9+' : idx.toString()}</MenuItem>)}
                     </SelectValidator>
                     <p className="childrenAgeText">Children up to 9 years old</p>
@@ -596,6 +598,7 @@ class Form extends Component {
                           id: 'numberOfChildren',
                         }}
                     >
+                      <ScrollLock />
                       {counts.map(idx => <MenuItem key={idx} value={idx}>{idx === 9 ? '9+' : idx.toString()}</MenuItem>)}
                     </SelectValidator>
                   </div>
@@ -613,6 +616,7 @@ class Form extends Component {
                           id: 'reaction',
                         }}
                     >
+                      <ScrollLock />
                       {reactions.map((reaction, idx) => <MenuItem key={idx} value={reaction}>{reaction}</MenuItem>)}
                     </SelectValidator>
                     {reaction === 'Other' ?
@@ -646,6 +650,7 @@ class Form extends Component {
                           id: 'numberOfDogs',
                         }}
                     >
+                      <ScrollLock />
                       {counts.map(idx => <MenuItem key={idx} value={idx}>{idx.toString()}</MenuItem>)}
                     </SelectValidator>
                     {numberOfDogs > 0 ?
@@ -661,6 +666,7 @@ class Form extends Component {
                                 id: 'dogSize',
                               }}
                           >
+                            <ScrollLock />
                             {dogSizes.map((size, idx) => <MenuItem key={idx} value={size}>{size}</MenuItem>)}
                           </SelectValidator>
                           <SelectValidator
@@ -674,6 +680,7 @@ class Form extends Component {
                                 id: 'onLeash',
                               }}
                           >
+                            <ScrollLock />
                             {leashOptions.map((option, idx) => <MenuItem key={idx} value={option}>{option}</MenuItem>)}
                           </SelectValidator>
                         </div> : null
@@ -702,6 +709,7 @@ class Form extends Component {
                           id: 'animalBehavior',
                         }}
                     >
+                      <ScrollLock />
                       {animalBehaviors.map((behavior, idx) => <MenuItem key={idx} value={behavior}>{behavior}</MenuItem>)}
                     </SelectValidator>
 
@@ -738,6 +746,7 @@ class Form extends Component {
                           id: 'vocalization',
                         }}
                     >
+                      <ScrollLock />
                       {vocalizations.map((type, idx) => <MenuItem key={idx} value={type}>{type}</MenuItem>)}
                     </SelectValidator>
 
@@ -774,6 +783,7 @@ class Form extends Component {
                           id: 'carnivoreResponse',
                         }}
                     >
+                      <ScrollLock />
                       {carnivoreResponses.map((type, idx) =>
                           <MenuItem
                               style={{ whiteSpace: 'normal', marginBottom: '10px' }}
@@ -794,6 +804,7 @@ class Form extends Component {
                           id: 'carnivoreConflict',
                         }}
                     >
+                      <ScrollLock />
                       {conflictOptions.map((type, idx) =>
                           <MenuItem
                               style={{ whiteSpace: 'normal', marginBottom: '10px' }}

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -13,6 +13,7 @@ import DatePicker from 'react-datepicker';
 import { ValidatorForm, TextValidator, SelectValidator } from 'react-material-ui-form-validator';
 import 'react-datepicker/dist/react-datepicker.css';
 import LoadingOverlay from 'react-loading-overlay';
+import ScrollLock from 'react-scrolllock';
 
 import MediaUpload from './MediaUpload';
 import FormMap from './FormMap';
@@ -520,7 +521,9 @@ class Form extends Component {
                 id: 'confidence',
               }}
             >
-              {confidenceLevels.map((level, idx) => <MenuItem key={idx} value={level}>{level}</MenuItem>)}
+              <ScrollLock>
+                {confidenceLevels.map((level, idx) => <MenuItem key={idx} value={level}>{level}</MenuItem>)}
+              </ScrollLock>
             </SelectValidator>
           </div>
 


### PR DESCRIPTION
Material-ui popups don't play nicely with iOS Safari scrolling (see https://github.com/mui-org/material-ui/issues/5750 for a semi-related example). This adds a scroll lock to each dropdown on the form page -- previously, we were able to scroll on mobile Safari, which allowed the menu to become unattached from the menu items. See the screenshot below for an example:
![IMG_A07C2B3003AD-1](https://user-images.githubusercontent.com/12106730/61164336-13423a80-a4c9-11e9-939f-56a2cc5abc62.jpeg)

This PR resolves this issue thanks to the folks at [react scroll-lock](https://github.com/jossmac/react-scrolllock)! 🎉
