### PR TITLE
Form dialog defaults to ok button; increase file size limit

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -50,8 +50,8 @@ const counts = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 // constants
 const THANKS_FOR_SUBMITTING = 'Thank you for your submission! Please note that the system will display your observation on the map after a period of one week.';
 const ERROR_ON_SUBMISSION = 'Something went wrong during your submission. Please try again later.';
-const FILES_TOO_LARGE = 'Please choose a set of files to upload that are smaller than 5MB in total.';
-const MAX_FILE_SIZE = 5242880; // 5MiB
+const FILES_TOO_LARGE = 'Please choose a set of files to upload that are smaller than 10MB in total.';
+const MAX_FILE_SIZE = 10485760; // 10MiB
 const neighborhoodService = new NeighborhoodService();
 const DIALOG_MODES = {
   THANKS: 'thanks',

--- a/src/components/FormInfoDialog.js
+++ b/src/components/FormInfoDialog.js
@@ -28,7 +28,11 @@ const FormInfoDialog = (props) => {
                     <Button onClick={yesButton.onClick} color="primary">
                         {yesButton.message}
                     </Button>: null }
-            </DialogActions> : null
+            </DialogActions> :
+        //  Default to an 'ok' button
+            <DialogActions>
+                <Button onClick={onClose} color={"primary"}>Ok</Button>
+            </DialogActions>
         }
     </Dialog>
 };


### PR DESCRIPTION
John had two requests related to the file submission workflow:

1. The file size is too small -- try 10MB.
2. "Unable to easily get rid of the error message. Maybe add X to upper right corner of every box."

This PR handles both of those -- instead of an X in the upper right corner, I added an "ok" button. Clicking outside of the box should still close the dialog as before, also.
![image](https://user-images.githubusercontent.com/12106730/61257327-73351d00-a725-11e9-8425-9f89bac965e0.png)

As a possible future extension, we could look into a smarter workflow for handling video/audio, since I think storing raw video is still going to be a little heavy. 