### PR TITLE
Date Input issues

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -474,6 +474,7 @@ padding: 0;
 }
 
 .constantHeightMapContainer {
-    height: 300px
+    height: 300px;
+    z-index: -1;
 }
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -394,7 +394,6 @@ class Form extends Component {
       </ScrollLock>
     )
   };
-
   renderMap = (classes, isMobile, neighborhood, mapLng, mapLat) => {
     return isMobile ?
         <div className="formItem">

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -132,7 +132,7 @@ const styles = {
     position: 'absolute',
     left: '34%',
     top: '15%',
-    zIndex: 100,
+    zIndex: 0,
   },
   doneButtonContainer: {
     display: 'flex',
@@ -147,6 +147,15 @@ const styles = {
     flex: 1,
   }
 };
+
+class CustomDatePickerInput extends Component {
+  render = () => <input
+    onClick={this.props.onClick}
+    value={this.props.value}
+    type="text"
+    readOnly={true}
+  />;
+}
 
 class Form extends Component {
   state = {
@@ -354,7 +363,7 @@ class Form extends Component {
         return <FormInfoDialog
           open={true}
           onClose={() => this.setState({dialogMode: DIALOG_MODES.CLOSED})}
-          message={"Is is ok if we store the images and audio that you've uploaded? If you say no, we will not be able to show your pictures to other users"}
+          message={"Is it ok if we store the images and audio that you've uploaded? If you say no, we will not be able to show your pictures to other users"}
           noButton={{onClick: () => this.handlePermissionResponse(false), message: "No, don't use my media"}}
           yesButton={{onClick: () => this.handlePermissionResponse(true), message: "Yes, use my media"}}/>;
       case DIALOG_MODES.THANKS:
@@ -385,6 +394,7 @@ class Form extends Component {
       </ScrollLock>
     )
   };
+
   renderMap = (classes, isMobile, neighborhood, mapLng, mapLat) => {
     return isMobile ?
         <div className="formItem">
@@ -436,7 +446,7 @@ class Form extends Component {
               dateFormat="MMMM d, yyyy h:mm aa"
               timeCaption="time"
               maxDate={new Date()}
-              onFocus={(e) => e.target.readOnly = true}
+              customInput={<CustomDatePickerInput/>}
             />
           </div>
           {this.renderMap(classes, isMobile,neighborhood, mapLng, mapLat)}

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -436,6 +436,7 @@ class Form extends Component {
               dateFormat="MMMM d, yyyy h:mm aa"
               timeCaption="time"
               maxDate={new Date()}
+              onFocus={(e) => e.target.readOnly = true}
             />
           </div>
           {this.renderMap(classes, isMobile,neighborhood, mapLng, mapLat)}

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -148,6 +148,7 @@ const styles = {
   }
 };
 
+//https://github.com/Hacker0x01/react-datepicker/issues/942#issuecomment-485934975
 class CustomDatePickerInput extends Component {
   render = () => <input
     onClick={this.props.onClick}
@@ -436,6 +437,7 @@ class Form extends Component {
                        className="formWizardBody" autoComplete="off">
           <div className="formItem">
             <h4>When did you see the animal?</h4>
+            {/*See https://github.com/Hacker0x01/react-datepicker/issues/942#issuecomment-485934975 for more information*/}
             <DatePicker
               selected={timestamp}
               onChange={this.handleTimestampChange}


### PR DESCRIPTION
The form's datepicker has a couple issues on mobile:

 - Currently "Edit Location" floats over the datepicker, preventing the user from clicking on certain dates.
 - The virtual keyboard pops up, obscuring part of the pop-up picker and making it nearly unusable.

This PR fixes both of these issues. The pop-up has a z-index of 1, so I gave the map a z-index of -1 and the button a z-index of 0. The virtual keyboard is an open issue with the react-datepicker component, but has a workaround here: https://github.com/Hacker0x01/react-datepicker/issues/942#issuecomment-485934975. Basically, setting the inner `<input />` to readOnly gets us what we want.