### PR TITLE
Fix radio buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -198,10 +198,6 @@ Form Wizard Styles
     color: gray;
 }
 
-input {
-    background-color: transparent;
-}
-
 /*
 List + Card
  */


### PR DESCRIPTION
The radio buttons were behaving weirdly on mobile iOS because their background was set to transparent. This removes that behavior.

I also glanced at the other input elements and verified that they looked normal.

Take a look at the new selected radio buttons from my phone:
![image](https://user-images.githubusercontent.com/12106730/61338959-7ba65a00-a7f0-11e9-91cd-3dac78620ca8.png)
