### PR TITLE
Compress images, add progress indicator, and fix a couple issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5580,6 +5580,11 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
+    "browser-image-compression": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-1.0.6.tgz",
+      "integrity": "sha512-gb++v1g26BgV/I9qrdXNzirFLDGcOiPmobVxuTJymNTFHbbxJnZ74o1GRoYHjDTgOt1Iypqh4Wk1K03C8tjXHQ=="
+    },
     "browser-process-hrtime": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@material-ui/icons": "^3.0.2",
     "@turf/turf": "^5.1.6",
     "axios": "^0.18.0",
+    "browser-image-compression": "^1.0.6",
     "cors": "^2.8.5",
     "dotenv": "^6.2.0",
     "firebase": "^5.8.3",

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -200,7 +200,7 @@ class Form extends Component {
     editMode: false,
     addMode: false,
     finalMap: true,
-    uploading: false
+    spinnerActive: false
   };
 
   constructor(props) {
@@ -259,7 +259,7 @@ class Form extends Component {
   };
 
   handleUploadSuccess = files => {
-    this.setState({ mediaPaths: files, media: null, uploading: false });
+    this.setState((prevState) => ({ mediaPaths: [...prevState.mediaPaths, ...files], media: null, spinnerActive: false }));
   };
 
   handleTimestampChange = timestamp => {
@@ -281,7 +281,7 @@ class Form extends Component {
         // Remove files and ask user to upload smaller files
         this.setState({dialogMode: DIALOG_MODES.LARGE_FILES});
       } else {
-        this.setState({ uploading: true });
+        this.setState({ spinnerActive: true });
         // Upload the files
         media.forEach(file => this.fileUploader.startUpload(file));
       }
@@ -426,7 +426,7 @@ class Form extends Component {
       numberOfYoungSpecies, numberOfAdults, numberOfChildren, reaction, reactionDescription, numberOfDogs, dogSize,
       onLeash, animalBehavior, animalEating, vocalization, vocalizationDesc, carnivoreResponse, carnivoreConflict, 
       conflictDesc, contactName, contactEmail, contactPhone, generalComments, mediaPaths, media, submitting,
-      neighborhood, dialogMode, showObserverDetails, showAnimalBehavior, showContactInformation, uploading, addMode
+      neighborhood, dialogMode, showObserverDetails, showAnimalBehavior, showContactInformation, spinnerActive, addMode
     } = this.state;
     const {classes, isMobile} = this.props;
     return (
@@ -465,9 +465,9 @@ class Form extends Component {
           {/*Image*/}
           <div className="formItem">
             <h4>Upload pictures, videos or sound files</h4>
-            <MediaUpload uploadMedia={this.setMedia} getMediaPaths={this.handleUploadSuccess}/>
+            <MediaUpload uploadMedia={this.setMedia} getMediaPaths={this.handleUploadSuccess} setSpinner={(bool) => this.setState({spinnerActive: bool})}/>
             <MediaDisplay filesOnDeck={media}
-                          uploading={uploading}
+                          uploading={spinnerActive}
                           uploadedFiles={mediaPaths}
                           removeFiles={() => this.setState({media: null})}/>
           {media && media.length > 0 ?

--- a/src/components/MediaDisplay.js
+++ b/src/components/MediaDisplay.js
@@ -56,7 +56,7 @@ const MediaDisplay = (props) => {
       </div>
       : null}
 
-    {filesOnDeck && filesOnDeck.length > 0 && uploading ?
+    {uploading ?
       <CircularProgress/>
       : null}
     {uploadedFiles && uploadedFiles.length > 0 ?

--- a/src/components/MediaUpload.js
+++ b/src/components/MediaUpload.js
@@ -38,7 +38,7 @@ class MediaUpload extends Component {
   };
 
   render() {
-    const { classes } = this.props;
+    const { classes, setSpinner } = this.props;
 
     return (
       <Grid container className={classes.root} spacing={16}>
@@ -51,7 +51,7 @@ class MediaUpload extends Component {
                   <AddIcon/>
                   <p>Photos</p>
                   <Uploader acceptType="images/*" reference="images" getMedia={this.getMedia}
-                            passPaths={this.getUploaderPaths}/>
+                            passPaths={this.getUploaderPaths} setSpinner={setSpinner}/>
                 </label>
               </Paper>
             </Grid>
@@ -62,7 +62,7 @@ class MediaUpload extends Component {
                   <AddIcon/>
                   <p>Videos</p>
                   <Uploader acceptType="video/*" reference="videos" getMedia={this.getMedia}
-                            passPaths={this.getUploaderPaths}/>
+                            passPaths={this.getUploaderPaths} setSpinner={setSpinner}/>
                 </label>
               </Paper>
             </Grid>
@@ -73,7 +73,7 @@ class MediaUpload extends Component {
                   <AddIcon/>
                   <p>Sound files</p>
                   <Uploader acceptType="audio/*" reference="audio" getMedia={this.getMedia}
-                            passPaths={this.getUploaderPaths}/>
+                            passPaths={this.getUploaderPaths} setSpinner={setSpinner}/>
                 </label>
               </Paper>
             </Grid>


### PR DESCRIPTION
There were a couple issues with the media upload workflow: 

- If you upload an image, then upload a video, both get uploaded to firebase. However, `handleUploadSuccess` only associates the most recent file upload with the report. This manifests itself in a couple ways: the indicator would say "1 file uploaded" despite there being two files uploaded, and only one type of media shows up in the report viewer after the report is submitted. I updated `handleUploadSuccess` to keep track of previous uploads in addition to the current upload.
- Some browsers respect EXIF rotation data, causing some images to rotate on some browsers. Unfortunately there isn't a standard solution out there for this. On the plus side, the compression library (see below) strips out EXIF data as part of the compression process, so this shouldn't be an issue.
- **We now compress images down to .5MB before upload!** 🎊 This number is easy to change so I'm happy to change it around if necessary. This process takes a second or so, so  I added some logic to display a loading spinner while the image compresses. Audio and video are still uncompressed, and we still check to make sure that we're uploading less than 10MB per report.
- When uploading anything besides an image, the "upload successful" indicator never appeared. This is because we were always listening for the file to be created under `/images` despite putting videos under `/video` and audio under `/audio`. I updated the logic to fix this.

I think that our current slideshow/multimedia display doesn't handle videos (maybe just certain formats) well, but that's something for a separate PR. For example, take a look at [this report I just uploaded](http://localhost:3000/urban-carnivore-spotter/reports/OIoJFr4nSh1ObftEIjqF). The [video is being served properly from firebase](https://firebasestorage.googleapis.com/v0/b/seattlecarnivores-edca2.appspot.com/o/videos%2Fe547af2d-83f0-4239-9527-d1c9711392a7.MOV?alt=media&token=5057b5dd-6210-47ae-a620-944606c6820f) but isn't displaying on the site at all.