### PR TITLE
Add a splash page + cookie support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3939,6 +3939,30 @@
         }
       }
     },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
+      }
+    },
     "@types/jss": {
       "version": "9.5.7",
       "resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.5.7.tgz",
@@ -3952,6 +3976,11 @@
       "version": "11.11.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
       "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+    },
+    "@types/object-assign": {
+      "version": "4.0.30",
+      "resolved": "https://registry.npmjs.org/@types/object-assign/-/object-assign-4.0.30.tgz",
+      "integrity": "sha1-iUk3HVqZ9Dge4PHfCpt6GH4H5lI="
     },
     "@types/prop-types": {
       "version": "15.5.9",
@@ -17346,6 +17375,26 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "react-cookie": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.0.1.tgz",
+      "integrity": "sha512-h61qAtSXvfjNa81h3XCFdFoyFaF+nb7gjK0cxQuTiCPMPAe50D950FjLCFhaIfSpAesQFAmkxf5XFpWoEVBDAA==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
+      }
+    },
     "react-date-picker": {
       "version": "7.5.1",
       "resolved": "https://registry.npmjs.org/react-date-picker/-/react-date-picker-7.5.1.tgz",
@@ -20656,6 +20705,24 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
       "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+    },
+    "universal-cookie": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.2.tgz",
+      "integrity": "sha512-n14lhA//lQeYRweP9j9uXsshN9Cs4LunVSnvAGmnA69SofwsjpUU03geaCaPC9LlsH2rkBy99o3zxQyVOldGvA==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "@types/object-assign": "^4.0.30",
+        "cookie": "^0.4.0",
+        "object-assign": "^4.1.1"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+        }
+      }
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "moment": "^2.24.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.2",
+    "react-cookie": "^4.0.1",
     "react-date-picker": "^7.5.1",
     "react-datepicker": "^2.3.0",
     "react-dates": "^20.2.2",

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -8,12 +8,10 @@ import ReportViewer from "./ReportViewer";
 import NotFound from './NotFound';
 import ResourceCard from "./ResourceCard";
 import Resources from "./Resources";
-import {Dialog, DialogContent} from "@material-ui/core";
-import {withCookies} from "react-cookie";
+import SplashPage from "./SplashPage";
 
-const VISITED_BEFORE = "visitedBefore";
 
-const Main = (props) => (
+const Main = () => (
   <main className="Main">
     <Switch>
       <Route exact path="/" render={() => <MapView/>}/>
@@ -24,25 +22,8 @@ const Main = (props) => (
       <Route exact path="/resources/:species" component={ResourceCard}/>
       <Route component={NotFound}/>
     </Switch>
-    <Dialog open={!props.cookies.get(VISITED_BEFORE)}
-      onClose={() => props.cookies.set(VISITED_BEFORE, true)}>
-      <DialogContent>
-        <p>The Seattle Urban Carnivore project is a partnership between Woodland Park Zoo and Seattle University and aims to explore how mammalian carnivores live and interact with people across urban and suburban areas in the Seattle region.</p>
-        <p>The project focuses on the following species:</p>
-        <ul>
-          <li>Black Bear</li>
-          <li>Bobcat</li>
-          <li>Cougar / Mountain Lion</li>
-          <li>Coyote</li>
-          <li>Opossum</li>
-          <li>Raccoon</li>
-          <li>River Otter</li>
-        </ul>
-        <p>These are terrestrial (not marine) mammals in the taxonomic Order Carnivora (*except for opossums). Some of them have a carnivorous diet (eating other animals). Many of them, however, have an omnivorous diet, eating plants as well as animals.</p>
-        <p>You can use this observation form to submit observations of any of the above animals (or if you think you may have seen one of them, but aren’t sure!)</p>
-      </DialogContent>
-    </Dialog>
+    <SplashPage />
   </main>
 );
 
-export default withCookies(Main);
+export default Main;

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -8,9 +8,11 @@ import ReportViewer from "./ReportViewer";
 import NotFound from './NotFound';
 import ResourceCard from "./ResourceCard";
 import Resources from "./Resources";
+import {Dialog, DialogContent} from "@material-ui/core";
+import {withCookies} from "react-cookie";
 
 
-const Main = () => (
+const Main = (props) => (
   <main className="Main">
     <Switch>
       <Route exact path="/" render={() => <MapView/>}/>
@@ -21,7 +23,25 @@ const Main = () => (
       <Route exact path="/resources/:species" component={ResourceCard}/>
       <Route component={NotFound}/>
     </Switch>
+    <Dialog open={!props.cookies.get("visitedBefore")}
+      onClose={() => props.cookies.set("visitedBefore", true)}>
+      <DialogContent>
+        <p>The Seattle Urban Carnivore project is a partnership between Woodland Park Zoo and Seattle University and aims to explore how mammalian carnivores live and interact with people across urban and suburban areas in the Seattle region.</p>
+        <p>The project focuses on the following species:</p>
+        <ul>
+          <li>Black Bear</li>
+          <li>Bobcat</li>
+          <li>Cougar / Mountain Lion</li>
+          <li>Coyote</li>
+          <li>Opossum</li>
+          <li>Raccoon</li>
+          <li>River Otter</li>
+        </ul>
+        <p>These are terrestrial (not marine) mammals in the taxonomic Order Carnivora (*except for opossums). Some of them have a carnivorous diet (eating other animals). Many of them, however, have an omnivorous diet, eating plants as well as animals.</p>
+        <p>You can use this observation form to submit observations of any of the above animals (or if you think you may have seen one of them, but aren’t sure!)</p>
+      </DialogContent>
+    </Dialog>
   </main>
 );
 
-export default Main;
+export default withCookies(Main);

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -11,6 +11,7 @@ import Resources from "./Resources";
 import {Dialog, DialogContent} from "@material-ui/core";
 import {withCookies} from "react-cookie";
 
+const VISITED_BEFORE = "visitedBefore";
 
 const Main = (props) => (
   <main className="Main">
@@ -23,8 +24,8 @@ const Main = (props) => (
       <Route exact path="/resources/:species" component={ResourceCard}/>
       <Route component={NotFound}/>
     </Switch>
-    <Dialog open={!props.cookies.get("visitedBefore")}
-      onClose={() => props.cookies.set("visitedBefore", true)}>
+    <Dialog open={!props.cookies.get(VISITED_BEFORE)}
+      onClose={() => props.cookies.set(VISITED_BEFORE, true)}>
       <DialogContent>
         <p>The Seattle Urban Carnivore project is a partnership between Woodland Park Zoo and Seattle University and aims to explore how mammalian carnivores live and interact with people across urban and suburban areas in the Seattle region.</p>
         <p>The project focuses on the following species:</p>

--- a/src/components/SplashPage.js
+++ b/src/components/SplashPage.js
@@ -26,7 +26,7 @@ const SplashPage = (props) => {
         <li className={classes.bulleted}>Raccoon</li>
         <li className={classes.bulleted}>River Otter</li>
       </ul>
-      <p>These are terrestrial (not marine) mammals in the taxonomic Order Carnivora (*except for opossums). Some of them have a carnivorous diet (eating other animals). Many of them, however, have an omnivorous diet, eating plants as well as animals.</p>
+      <p>These are terrestrial (not marine) mammals in the taxonomic order Carnivora (*except for opossums). Some of them have a carnivorous diet (eating other animals). Many of them, however, have an omnivorous diet, eating plants as well as animals.</p>
       <p>You can use this observation form to submit observations of any of the above animals (or if you think you may have seen one of them, but aren’t sure!)</p>
     </DialogContent>
   </Dialog>

--- a/src/components/SplashPage.js
+++ b/src/components/SplashPage.js
@@ -1,0 +1,35 @@
+import React from "react";
+import {Dialog, DialogContent} from "@material-ui/core";
+import {withStyles} from "@material-ui/core";
+import {withCookies} from "react-cookie";
+const VISITED_BEFORE = "visitedBefore";
+
+const styles = {
+  bulleted: {
+    listStyleType: 'disc'
+  }
+};
+
+const SplashPage = (props) => {
+  const {cookies, classes} = props;
+  return <Dialog open={!cookies.get(VISITED_BEFORE)}
+          onClose={() => cookies.set(VISITED_BEFORE, true)}>
+    <DialogContent>
+      <p>The Seattle Urban Carnivore project is a partnership between Woodland Park Zoo and Seattle University and aims to explore how mammalian carnivores live and interact with people across urban and suburban areas in the Seattle region.</p>
+      <p>The project focuses on the following species:</p>
+      <ul>
+        <li className={classes.bulleted}>Black Bear</li>
+        <li className={classes.bulleted}>Bobcat</li>
+        <li className={classes.bulleted}>Cougar / Mountain Lion</li>
+        <li className={classes.bulleted}>Coyote</li>
+        <li className={classes.bulleted}>Opossum</li>
+        <li className={classes.bulleted}>Raccoon</li>
+        <li className={classes.bulleted}>River Otter</li>
+      </ul>
+      <p>These are terrestrial (not marine) mammals in the taxonomic Order Carnivora (*except for opossums). Some of them have a carnivorous diet (eating other animals). Many of them, however, have an omnivorous diet, eating plants as well as animals.</p>
+      <p>You can use this observation form to submit observations of any of the above animals (or if you think you may have seen one of them, but aren’t sure!)</p>
+    </DialogContent>
+  </Dialog>
+};
+
+export default withStyles(styles)(withCookies(SplashPage));

--- a/src/index.js
+++ b/src/index.js
@@ -8,13 +8,16 @@ import { store } from './store/index';
 import './index.css';
 import App from './App';
 import ScrollToTop from "./components/ScrollToTop";
+import {CookiesProvider} from "react-cookie";
 
 ReactDOM.render((
     <BrowserRouter basename="urban-carnivore-spotter">
       <ScrollToTop>
         <Provider store={store}>
           <FirebaseContext.Provider value={new Firebase()}>
-            <App/>
+            <CookiesProvider>
+              <App/>
+            </CookiesProvider>
           </FirebaseContext.Provider>
         </Provider>
       </ScrollToTop>


### PR DESCRIPTION
The first time that a user visits any page, we now have a dialog that pops up and explains the project. When the dialog is closed, we add a cookie "visitedBefore". The dialog looks for that cookie, and if it isn't present, displays itself. After we've visited the page once, notice the visitedBefore cookie:
![image](https://user-images.githubusercontent.com/12106730/61814479-0abcfe80-adfd-11e9-8b89-04cb12141cc6.png)

I have screenshots on the map page but have confirmed that this shows up on any page, as long as it's the first page that the user has visited. 

Looks like this on desktop:
![image](https://user-images.githubusercontent.com/12106730/61814218-6b980700-adfc-11e9-8fd8-4fa411909b55.png)

On mobile (the dialog is scrollable):
![IMG_984A267E3B1C-1](https://user-images.githubusercontent.com/12106730/61814182-5b802780-adfc-11e9-8d29-5c370756e169.jpeg)
