### PR TITLE
Adds support for video playback when viewing a report

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -446,3 +446,7 @@ padding: 0;
     z-index: -1;
 }
 
+.image-gallery-image video {
+    padding-bottom: 3rem;
+}
+

--- a/src/components/ReportViewer.js
+++ b/src/components/ReportViewer.js
@@ -13,6 +13,8 @@ import ImageGallery from 'react-image-gallery';
 
 const getReport = 'https://us-central1-seattlecarnivores-edca2.cloudfunctions.net/getReport';
 
+const videoFormats = ['.mov', '.mp4', '.webm', '.ogg', '.avi', '.wmv', '.mkv'];
+
 class ReportViewer extends Component {
   state = {
     report: null,
@@ -28,6 +30,33 @@ class ReportViewer extends Component {
       .catch(error => error);
   }
 
+  renderGalleryItem(item) {
+    return (
+      <div className='image-gallery-image'>
+        { item.isVideo ?
+          <video width="100%" controls autoPlay>
+            <source src={item.original} />
+          </video>
+        :
+          <img
+            src={item.original}
+            alt={item.originalAlt}
+            srcSet={item.srcSet}
+            sizes={item.sizes}
+            title={item.originalTitle}
+          />
+        }
+
+        {
+          item.description &&
+            <span className='image-gallery-description'>
+              {item.description}
+            </span>
+        }
+      </div>
+    );
+  }
+
   render() {
     const { history } = this.props;
     const { report } = this.state;
@@ -41,7 +70,10 @@ class ReportViewer extends Component {
 
     if (report.mediaPaths !== undefined && report.mediaPaths.length > 0) {
       report.mediaPaths.map(med => {
-        media.push({ original: med, thumbnail: med });
+        const fileExtensionPattern = /\.([0-9a-z]+)(?=[?#])|(\.)(?:[\w]+)$/gmi
+        const extension = med.match(fileExtensionPattern)[0];
+        const isVideo = videoFormats.includes(extension.toLowerCase());
+        media.push({ original: med, thumbnail: med, isVideo: isVideo, ext: extension });
       })
     }
 
@@ -55,6 +87,7 @@ class ReportViewer extends Component {
         <Card className="reportCard">
           {media ?
             <ImageGallery items={media}
+                          renderItem={this.renderGalleryItem}
                           showBullets={true} showIndex={false}
                           showThumbnails={false} showVideo={true}/> : null}
           <div style={{ backgroundColor: 'white', textAlign: 'left', paddingLeft: '30px'}}>


### PR DESCRIPTION
Uses regex to extract the media type from the media url returned from firebase. If the video format is supported then we display an html5 video tag - otherwise we fallback to a simple img.