### PR TITLE
Prettify the notification email

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,5 +1,5 @@
 const functions = require('firebase-functions');
-const cors = require('cors')({ origin: 'http://localhost' });
+const cors = require('cors')({ origin: true });
 const admin = require('firebase-admin');
 const moment = require('moment');
 const turf = require('@turf/turf');

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,5 +1,5 @@
 const functions = require('firebase-functions');
-const cors = require('cors')({ origin: true });
+const cors = require('cors')({ origin: 'http://localhost' });
 const admin = require('firebase-admin');
 const moment = require('moment');
 const turf = require('@turf/turf');
@@ -80,7 +80,7 @@ exports.getReport = functions.https.onRequest((req, res) => {
  */
 buildQuery = (queryParams, collection) => {
   // always filter by time_submitted
-  // let week_ago = toTimestamp(moment().subtract(1, 'week').toDate());
+  // let week_ago = toTimestamp(moment().subtract(10, 'days').toDate());
   // let initialQuery = collection.where('time_submitted', '<=', week_ago);
   let initialQuery = collection;
   if (queryParams.species) {
@@ -174,7 +174,7 @@ exports.getNeighborhoods = functions.https.onRequest((req, res) => {
 });
 
 // Email helpers
-const sendEmail = (from, to, subject, text) => {
+const sendEmail = (from, to, subject, html) => {
 
     const transporter = nodemailer.createTransport({
         service: 'gmail',
@@ -184,21 +184,94 @@ const sendEmail = (from, to, subject, text) => {
         }
     });
 
-    const mailOptions = { from, to, subject, text };
+    const mailOptions = { from, to, subject, html };
 
     return transporter.sendMail(mailOptions);
 };
 
-sendNewSubmissionEmail = (reportSnapshot) => {
-    const from = `"Test reporters" <${username}@example.com>`;
-    const to = `"Seattle Carnivore Spotter" <seattlecarnivores@gmail.com>`;
-    const subject = "New report submitted";
-    const text = `A new report was submitted with the following characteristics:
-        ID: ${reportSnapshot.id}
-        ${JSON.stringify(reportSnapshot.data())}
+const formatMediaPathAsTableRow = (mediaPath, index, total) => {
+  // Each mediaPath looks like
+  // https://base-url.com/v0/b/app-url/o/images%2Fmedia-id-here.jpeg?some-query-params
+  const firstSplit = mediaPath.split("%2F");
+  const id = firstSplit[1].split(".")[0];
+  const segments = firstSplit[0].split("/");
+  const location = segments[segments.length - 1];
+  const thumbnail = mediaPath.includes("images") ? `<img src=${mediaPath} alt="image thumbnail" style="width: 100px;"/>`
+                                                 : "No thumbnail for non-image media.";
+  // Don't style the bottom row, since we have a border around everything.
+  const trStyle = index === total - 1 ? '' : ' style="border-bottom: 1px solid black"';
+  return `<tr${trStyle}>
+        <td>${mediaPath}</td>
+        <td>${thumbnail}</td>
+        <td>${location}: ${id}</td>
+    </tr>`;
+};
 
-        This report can be accessed at ${REPORT_URL_STUB}${reportSnapshot.id}`;
-    return sendEmail(from, to, subject, text);
+const formatSubmissionAsTable = (reportSnapshot) => {
+  const id = reportSnapshot.id;
+  const data = reportSnapshot.data();
+  const mediaPaths = data.mediaPaths;
+  const neighborhood = data.neighborhood;
+  const vocalizationDescription = data.vocalizationDesc ? data.vocalizationDesc : 'N/A';
+  const reactionDescription = data.reactionDescription ? data.reactionDescription : 'N/A';
+  const name = data.contactName ? data.contactName : 'N/A';
+  const email = data.contactEmail ? data.contactEmail : 'N/A';
+  const phone = data.contactPhone ? data.contactPhone : 'N/A';
+  const comments = data.generalComments ? data.generalComments : 'N/A';
+
+  return `<table style="border: 1px solid black">
+     <tr>
+       <th>ID</th>
+       <th>Media</th>
+       <th>Neighborhood</th>
+       <th>Optional Text Comments</th>
+       <th>Contact Information</th>
+       <th>Link to Report</th>
+     </tr>
+     <tr>
+        <td>${id}</td>
+        <td>
+            <table>
+                <tr>
+                  <th>Media Paths</th>
+                  <th>Media Thumbnails</th>
+                  <th>Media IDs</th>
+                </tr>
+                ${mediaPaths.map((path, index) => formatMediaPathAsTableRow(path, index, mediaPaths.length)).join("")}
+            </table>
+        </td>
+        <td>${neighborhood}</td>
+        <td><strong>Vocalization:</strong> ${vocalizationDescription}<br/>
+            <strong>Reaction:</strong> ${reactionDescription}<br/>
+            <strong>General comments:</strong> ${comments}
+        </td>
+        <strong>Name:</strong> ${name}<br/>
+            <strong>Email:</strong> ${email}<br/>
+            <strong>Phone:</strong> ${phone}
+        </td>
+        <td>${REPORT_URL_STUB}${id}</td>
+     </tr>
+   </table>`;
+};
+
+const sendNewSubmissionEmail = (reportSnapshot) => {
+    const from = `"Test reporters" <${username}@example.com>`;
+    const to = `"Seattle Carnivore Spotter" <mjnacht@gmail.com>`;
+    const subject = "New report submitted";
+    const styles = `<style>
+        table td + td { 
+            border-left: 1px solid black;
+        }
+        table {
+            border-collapse: collapse;
+        }
+        th {
+            border-bottom: 1px solid black;
+        }
+    </style>`;
+    const html = `<head>${styles}</head>A new report was submitted with the following characteristics:<br/>
+        ${formatSubmissionAsTable(reportSnapshot)}`;
+    return sendEmail(from, to, subject, html);
 };
 
 /**
@@ -206,5 +279,6 @@ sendNewSubmissionEmail = (reportSnapshot) => {
  */
 exports.reportAdded = functions.firestore.document(`${REPORTS}/{reportId}`)
     .onCreate((snapshot, context) => {
+      console.log('report added');
       sendNewSubmissionEmail(snapshot);
     });

--- a/functions/index.js
+++ b/functions/index.js
@@ -279,6 +279,5 @@ const sendNewSubmissionEmail = (reportSnapshot) => {
  */
 exports.reportAdded = functions.firestore.document(`${REPORTS}/{reportId}`)
     .onCreate((snapshot, context) => {
-      console.log('report added');
       sendNewSubmissionEmail(snapshot);
     });

--- a/functions/index.js
+++ b/functions/index.js
@@ -203,7 +203,8 @@ const formatMediaPathAsTableRow = (mediaPath, index, total) => {
   return `<tr${trStyle}>
         <td>${mediaPath}</td>
         <td>${thumbnail}</td>
-        <td>${location}: ${id}</td>
+        <td>${location}/</td>
+        <td>${id}</td>
     </tr>`;
 };
 
@@ -235,6 +236,7 @@ const formatSubmissionAsTable = (reportSnapshot) => {
                 <tr>
                   <th>Media Paths</th>
                   <th>Media Thumbnails</th>
+                  <th>Media Bucket</th>
                   <th>Media IDs</th>
                 </tr>
                 ${mediaPaths.map((path, index) => formatMediaPathAsTableRow(path, index, mediaPaths.length)).join("")}

--- a/functions/index.js
+++ b/functions/index.js
@@ -256,7 +256,7 @@ const formatSubmissionAsTable = (reportSnapshot) => {
 
 const sendNewSubmissionEmail = (reportSnapshot) => {
     const from = `"Test reporters" <${username}@example.com>`;
-    const to = `"Seattle Carnivore Spotter" <mjnacht@gmail.com>`;
+    const to = `"Seattle Carnivore Spotter" <seattlecarnivores@gmail.com>`;
     const subject = "New report submitted";
     const styles = `<style>
         table td + td { 

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -2947,6 +2947,16 @@
         }
       }
     },
+    "firebase-functions-test": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/firebase-functions-test/-/firebase-functions-test-0.1.6.tgz",
+      "integrity": "sha512-sITLbQunI75gL690qFOq4mqxUEcdETEbY4HcLFawWVJC3PmlSFt81mhfZjJe45GJTt1+7xeowaHQx3jpnoPNpA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "^4.14.104",
+        "lodash": "^4.17.5"
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",

--- a/functions/package.json
+++ b/functions/package.json
@@ -21,7 +21,8 @@
   },
   "devDependencies": {
     "eslint": "^5.12.0",
-    "eslint-plugin-promise": "^4.0.1"
+    "eslint-plugin-promise": "^4.0.1",
+    "firebase-functions-test": "^0.1.6"
   },
   "private": true
 }

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -49,7 +49,7 @@ const conflictOptions = ['There was no interaction','Animal made physical contac
 const counts = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
 // constants
-const THANKS_FOR_SUBMITTING = 'Thank you for your submission! Please note that the system will display your observation on the map after a period of one week.';
+const THANKS_FOR_SUBMITTING = 'Thank you for your submission! Please note that the system will display your observation on the map after a period of ten days.';
 const ERROR_ON_SUBMISSION = 'Something went wrong during your submission. Please try again later.';
 const FILES_TOO_LARGE = 'Please choose a set of files to upload that are smaller than 10MB in total.';
 const MAX_FILE_SIZE = 10485760; // 10MiB


### PR DESCRIPTION
Before, the new report notification email was kind of a mess:
![image](https://user-images.githubusercontent.com/12106730/62329527-0337ce00-b46b-11e9-9d3c-717cdd74aada.png)

Now, it looks nice:
![image](https://user-images.githubusercontent.com/12106730/62329495-e8fdf000-b46a-11e9-9f35-5bd1c7cb9dc9.png)

In particular, after discussion with the zoo folks, they requested an easier-to-look at layout with the following information:
 - report ID
 - media uploaded (the quicker it is to scan through, the better)
 - neighborhood
 - comment fields (anywhere that a user can enter text

In addition, they requested that we move from a 7-day waiting period to a 10-day waiting period. I've updated the (commented-out) filter in our cloud function, and updated the notification to users when they submit a sighting.