### PR TITLE
Switch map order and separate species/other resources

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -435,6 +435,7 @@ class Form extends Component {
         <ValidatorForm onError={errors => console.log(errors)}
                        onSubmit={this.handleSubmit}
                        className="formWizardBody" autoComplete="off">
+          {this.renderMap(classes, isMobile,neighborhood, mapLng, mapLat)}
           <div className="formItem">
             <h4>When did you see the animal?</h4>
             {/*See https://github.com/Hacker0x01/react-datepicker/issues/942#issuecomment-485934975 for more information*/}
@@ -450,7 +451,6 @@ class Form extends Component {
               customInput={<CustomDatePickerInput/>}
             />
           </div>
-          {this.renderMap(classes, isMobile,neighborhood, mapLng, mapLat)}
           <div className="formItem">
             <Dialog
                 open={addMode}

--- a/src/components/ResourcesDesktop.js
+++ b/src/components/ResourcesDesktop.js
@@ -18,13 +18,14 @@ const styles = {
   },
   speciesContent: {
     marginTop: 72,
-
+    paddingBottom: 24
   },
   header: {
     textAlign: 'left',
   },
   content: {
-    textAlign: 'left'
+    textAlign: 'left',
+    paddingBottom: 24
   },
   tabsContainer: {
     margin: '0px -32px 0px -32px',
@@ -67,6 +68,7 @@ class ResourcesDesktop extends Component {
                                    imagePath={getImageBySpecies(currData.shortname)}
           />}
         </div>
+        <hr/>
         <div>
           <h3 className={classes.header}>Seattle Urban Carnivore Project</h3>
           <div className={classes.content}>
@@ -74,6 +76,7 @@ class ResourcesDesktop extends Component {
             <a href="https://www.zoo.org/otters">learn more</a>
           </div>
         </div>
+        <hr/>
         <div>
           <h3 className={classes.header}>Contact Us</h3>
           <div className={classes.content} >


### PR DESCRIPTION
There were a couple of outstanding issues from John's feedback.

 - "Hard to understand that you can scroll past the map to understand more questions"
   - This PR moves the map to the first question, so there's space below for more questions to appear. Also, there's no submission button until the bottom so the user should be able to figure out that they need to scroll.
![image](https://user-images.githubusercontent.com/12106730/62501846-66926a80-b7a1-11e9-91ae-d2f5605802ce.png)
 - "On a laptop browser, it looks like the "Seattle Urban Carnivore Project" and "Contact Us" headings are part of the identification tips information."
    - This PR adds a little bit of padding between the three topics, and adds an `<hr/>` between them. 
![image](https://user-images.githubusercontent.com/12106730/62501889-99d4f980-b7a1-11e9-888c-4f32de45b982.png)
