### PR TITLE
Urban Carnivore Sightings -> Carnivore Spotter

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Urban Carnivore Spotter</title>
+    <title>Carnivore Spotter</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Urban Carnivore Spotter",
-  "name": "Urban Carnivore Spotter",
+  "short_name": "Carnivore Spotter",
+  "name": "Carnivore Spotter",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/App.css
+++ b/src/App.css
@@ -116,12 +116,12 @@ Desktop Header
     font-size: 14px;
     color: white;
     position: absolute;
-    left: 27%;
+    left: 30%;
 }
 
 @media (min-width: 768px) {
     .headerTitle {
-        left: 26%;
+        left: 28%;
     }
 }
 
@@ -133,7 +133,7 @@ Desktop Header
 
 @media (min-width: 1280px) {
     .headerTitle {
-        left: 20%;
+        left: 21%;
     }
 }
 

--- a/src/components/DesktopHeader.js
+++ b/src/components/DesktopHeader.js
@@ -15,7 +15,7 @@ class DesktopHeader extends Component {
         <AppBar position="static" className="appBar">
           <div className="logo"/>
           <h1 className="headerTitle" onClick={() => history.push('/')} style={{ cursor: 'pointer' }}>
-            Urban Carnivore Sightings
+            Carnivore Spotter
           </h1>
           <div className="nav">
             <div id="explore" className="categories" onClick={() => history.push('/')}><h4 style={{textDecoration: history.location.pathname==='/'? "underline":""}}>Explore</h4></div>

--- a/src/components/MobileHeader.js
+++ b/src/components/MobileHeader.js
@@ -35,7 +35,7 @@ class MobileHeader extends Component {
         <AppBar position="static" color="default">
           <div className="headerDiv">
             <h1 style={{ display: 'table-cell', cursor: 'pointer', marginLeft: 20}}
-                onClick={() => history.push('/')} className="header">Urban Carnivore Spotter</h1>
+                onClick={() => history.push('/')} className="header">Carnivore Spotter</h1>
             {location.pathname === '/' || location.pathname === '/list' ?
               <Button className="filterButton" onClick={this.toggleDrawer('right', true)}>Filter</Button> :
               null

--- a/src/components/Resources.js
+++ b/src/components/Resources.js
@@ -124,7 +124,7 @@ class Resources extends Component {
                 {/* Seattle Urban Carnivore Project */}
                 {this.getCollapse(classes, "Seattle Urban Carnivore Project", this.toggleShow('showProjectDescription'), showProjectDescription,
                     <div className={classes.body}>
-                        <p>Urban Carnivore Spotter is part of the Seattle Urban Carnivore Project, a collaboration between the Seattle University and Woodland Park Zoo</p>
+                        <p>Carnivore Spotter is part of the Seattle Urban Carnivore Project, a collaboration between the Seattle University and Woodland Park Zoo</p>
                         <a href="https://www.zoo.org/otters">learn more</a>
                     </div>
 

--- a/src/components/ResourcesDesktop.js
+++ b/src/components/ResourcesDesktop.js
@@ -74,7 +74,7 @@ class ResourcesDesktop extends Component {
         <div>
           <h3 className={classes.header}>Seattle Urban Carnivore Project</h3>
           <div className={classes.content}>
-            <p>Urban Carnivore Spotter is part of the Seattle Urban Carnivore Project, a collaboration between the Seattle University and Woodland Park Zoo.</p>
+            <p>Carnivore Spotter is part of the Seattle Urban Carnivore Project, a collaboration between the Seattle University and Woodland Park Zoo.</p>
             <a href="https://www.zoo.org/otters">learn more</a>
           </div>
         </div>


### PR DESCRIPTION
WPZ wants the app to be called Carnivore Spotter. So, this PR updates the name accordingly. 

I also moved the title a little further left at a couple of breakpoints on desktop which I think will address their concerns about the name and the logo overlapping.
 
There's also the "Urban Carnivore Project," which I think remains the same. If needed, we could update those references to Carnivore Spotter as well.

Some screenshots:
![image](https://user-images.githubusercontent.com/12106730/62658853-a5016400-b91e-11e9-8ffb-a208ad0d71b4.png)
![image](https://user-images.githubusercontent.com/12106730/62658880-b21e5300-b91e-11e9-9934-19c39aecf21b.png)
![image](https://user-images.githubusercontent.com/12106730/62658920-cbbf9a80-b91e-11e9-8b7d-27ed60c80b18.png)
