### PR TITLE
Weekly digest actually weekly

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -315,7 +315,7 @@ exports.reportAdded = functions.firestore.document(`${REPORTS}/{reportId}`)
 /**
  * Every week, send a digest containing all of the submissions from the last week.
  */
-exports.weeklyDigest = functions.pubsub.schedule('0 0 * * *')
+exports.weeklyDigest = functions.pubsub.schedule('0 10 * * 2')
   .onRun(context => {
     const weekAgo = toTimestamp(moment().subtract(1, 'week').toDate());
     return database.collection(REPORTS)


### PR DESCRIPTION
I set the weekly digest to send an email every night in order to verify that it worked properly. At midnight last night, this email was sent out:
![image](https://user-images.githubusercontent.com/12106730/62718964-c4020380-b9bb-11e9-9788-5ef2ed3ae212.png)

This updates the frequency so now it is 12:10AM on Tuesday mornings (the zoo said they would likely check on Tuesdays and Thursdays).