### PR TITLE
Fix uploaded successfully count

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -188,7 +188,9 @@ class Form extends Component {
     generalComments: '',
     neighborhood: '',
     media: null,
-    mediaPaths: [],
+    imagePaths: [],
+    videoPaths: [],
+    audioPaths: [],
     dialogMode: DIALOG_MODES.CLOSED,
     submitting: false,
     permissionOpen: false,
@@ -244,8 +246,12 @@ class Form extends Component {
   };
 
   handleSubmit = () => {
-    let {dialogMode, submitting, ...report} = this.state;
+    // Pull out all of the fields we don't want to submit. Everything left in report will be submitted.
+    let {dialogMode, submitting, audioPaths, videoPaths, imagePaths, addMode, editMode, finalMap, carouselImageIndex,
+      permissionOpen, spinnerActive, showCarousel, showAnimalBehavior, showContactInformation, showObserverDetails,
+      ...report} = this.state;
     delete report['media'];
+    report.mediaPaths = [...audioPaths, ...videoPaths, ...imagePaths];
     this.setState({submitting: true});
     return axios.post(addReportUrl, report)
       .then(response => {
@@ -258,8 +264,9 @@ class Form extends Component {
       });
   };
 
-  handleUploadSuccess = files => {
-    this.setState((prevState) => ({ mediaPaths: [...prevState.mediaPaths, ...files], media: null, spinnerActive: false }));
+  handleUploadSuccess = mediaType => files => {
+    const pathsToUpdate = `${mediaType}Paths`;
+    this.setState({ [pathsToUpdate]: files, media: null, spinnerActive: false });
   };
 
   handleTimestampChange = timestamp => {
@@ -425,8 +432,9 @@ class Form extends Component {
       mapLat, mapLng, timestamp, confidence, numberOfAdultSpecies,
       numberOfYoungSpecies, numberOfAdults, numberOfChildren, reaction, reactionDescription, numberOfDogs, dogSize,
       onLeash, animalBehavior, animalEating, vocalization, vocalizationDesc, carnivoreResponse, carnivoreConflict, 
-      conflictDesc, contactName, contactEmail, contactPhone, generalComments, mediaPaths, media, submitting,
-      neighborhood, dialogMode, showObserverDetails, showAnimalBehavior, showContactInformation, spinnerActive, addMode
+      conflictDesc, contactName, contactEmail, contactPhone, generalComments, media, submitting,
+      neighborhood, dialogMode, showObserverDetails, showAnimalBehavior, showContactInformation, spinnerActive, addMode,
+      imagePaths, audioPaths, videoPaths
     } = this.state;
     const {classes, isMobile} = this.props;
     return (
@@ -468,7 +476,7 @@ class Form extends Component {
             <MediaUpload uploadMedia={this.setMedia} getMediaPaths={this.handleUploadSuccess} setSpinner={(bool) => this.setState({spinnerActive: bool})}/>
             <MediaDisplay filesOnDeck={media}
                           uploading={spinnerActive}
-                          uploadedFiles={mediaPaths}
+                          numUploadedFiles={imagePaths.length + audioPaths.length + videoPaths.length}
                           removeFiles={() => this.setState({media: null})}/>
           {media && media.length > 0 ?
             // Setting dialogMode to DIALOG_MODES.PERMISSION opens the permission dialog, where clicking "agree" actually calls the media upload function

--- a/src/components/MediaDisplay.js
+++ b/src/components/MediaDisplay.js
@@ -38,7 +38,7 @@ const styles = {
 };
 
 const MediaDisplay = (props) => {
-  const { filesOnDeck, uploading, uploadedFiles, removeFiles, classes } = props;
+  const { filesOnDeck, uploading, numUploadedFiles, removeFiles, classes } = props;
   return <div className={classes.allContent}>
     {filesOnDeck && filesOnDeck.length > 0 && !uploading ?
       <div>
@@ -59,8 +59,8 @@ const MediaDisplay = (props) => {
     {uploading ?
       <CircularProgress/>
       : null}
-    {uploadedFiles && uploadedFiles.length > 0 ?
-      <span className={`${classes.iconTextSpan} ${classes.green}`}><CheckCircleOutlinedIcon fontSize='small' className={classes.icon}/>{uploadedFiles.length} file(s) uploaded</span>
+    {numUploadedFiles > 0 ?
+      <span className={`${classes.iconTextSpan} ${classes.green}`}><CheckCircleOutlinedIcon fontSize='small' className={classes.icon}/>{numUploadedFiles} file(s) uploaded</span>
       : null}
   </div>
 };

--- a/src/components/MediaUpload.js
+++ b/src/components/MediaUpload.js
@@ -38,7 +38,7 @@ class MediaUpload extends Component {
   };
 
   render() {
-    const { classes, setSpinner } = this.props;
+    const { classes, setSpinner, getMediaPaths } = this.props;
 
     return (
       <Grid container className={classes.root} spacing={16}>
@@ -51,7 +51,7 @@ class MediaUpload extends Component {
                   <AddIcon/>
                   <p>Photos</p>
                   <Uploader acceptType="images/*" reference="images" getMedia={this.getMedia}
-                            passPaths={this.getUploaderPaths} setSpinner={setSpinner}/>
+                            passPaths={getMediaPaths("image")} setSpinner={setSpinner}/>
                 </label>
               </Paper>
             </Grid>
@@ -62,7 +62,7 @@ class MediaUpload extends Component {
                   <AddIcon/>
                   <p>Videos</p>
                   <Uploader acceptType="video/*" reference="videos" getMedia={this.getMedia}
-                            passPaths={this.getUploaderPaths} setSpinner={setSpinner}/>
+                            passPaths={getMediaPaths("video")} setSpinner={setSpinner}/>
                 </label>
               </Paper>
             </Grid>
@@ -73,7 +73,7 @@ class MediaUpload extends Component {
                   <AddIcon/>
                   <p>Sound files</p>
                   <Uploader acceptType="audio/*" reference="audio" getMedia={this.getMedia}
-                            passPaths={this.getUploaderPaths} setSpinner={setSpinner}/>
+                            passPaths={getMediaPaths("audio")} setSpinner={setSpinner}/>
                 </label>
               </Paper>
             </Grid>


### PR DESCRIPTION
The changes in #66 didn't quite address the issues with mediaPaths. Basically, the `files` object for each Uploader remembers its own files, so uploading file A, then file B gives a mediaPaths object of [A, ...[A, B]] -> [A, A, B] which is not what we want.

Instead, now we're keeping track of each type of media separately, and only combining them on actual upload. 

Now, we get:
 - Upload 1 video, upload 1 image -> 2 files uploaded (this was working as of #66 but was broken before)
 - Upload 1 image, upload another image -> 2 files uploaded (before this PR, this would report 3 files uploaded)