### PR TITLE
Deploy to Firebase

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -3,5 +3,19 @@
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint"
     ]
+  },
+  "hosting": {
+    "public": "build",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,5 @@
   "devDependencies": {
     "redux-devtools": "^3.5.0",
     "gh-pages": "^2.0.1"
-  },
-  "homepage": "http://spatialdev.github.io/urban-carnivore-spotter"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build -r git@github.com:spatialdev/urban-carnivore-spotter.git",
+    "deploy": "firebase deploy --only hosting",
+    "deploy-gh-pages": "npm run build && gh-pages -d build -r git@github.com:spatialdev/urban-carnivore-spotter.git",
     "gh-pages-help": "gh-pages --help"
   },
   "eslintConfig": {


### PR DESCRIPTION
`npm run deploy` now deploys to our [live production site](https://carnivorespotter.org/) 🎉 

I left in the old deploy script as `npm run deploy-gh-pages` in case we want to test things out before going external with them. Eventually we should have a staging version of cloud functions (and potentially the firestore as well).

Verified that it works with `npm run deploy` which you can see at the link above! 