### PR TITLE
Compatible with IE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14638,6 +14638,11 @@
         "find-up": "^2.1.0"
       }
     },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q=="
+    },
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
@@ -16998,9 +17003,9 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "promise": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.2.tgz",
-      "integrity": "sha512-EIyzM39FpVOMbqgzEHhxdrEhtOSDOtjMZQ0M6iVfCE+kWNgCkAyOdnuCWqfmflylftfadU6FkiMgHZA2kUzwRw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
+      "integrity": "sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==",
       "requires": {
         "asap": "~2.0.6"
       }
@@ -17351,21 +17356,27 @@
       }
     },
     "react-app-polyfill": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-0.2.2.tgz",
-      "integrity": "sha512-mAYn96B/nB6kWG87Ry70F4D4rsycU43VYTj3ZCbKP+SLJXwC0x6YCbwcICh3uW8/C9s1VgP197yx+w7SCWeDdQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-1.0.2.tgz",
+      "integrity": "sha512-yZcpLnIr0FOIzrOOz9JC37NWAWEuCaQWmYn9EWjEzlCW4cOmA5MkT5L3iP8QuUeFnoqVCTJgjIWYbXEJgNXhGA==",
       "requires": {
-        "core-js": "2.6.4",
+        "core-js": "3.1.4",
         "object-assign": "4.1.1",
-        "promise": "8.0.2",
+        "promise": "8.0.3",
         "raf": "3.4.1",
+        "regenerator-runtime": "0.13.3",
         "whatwg-fetch": "3.0.0"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
-          "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A=="
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
+          "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
         }
       }
     },
@@ -17930,10 +17941,35 @@
         "workbox-webpack-plugin": "3.6.3"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
+          "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A=="
+        },
         "dotenv": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
           "integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg=="
+        },
+        "promise": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.2.tgz",
+          "integrity": "sha512-EIyzM39FpVOMbqgzEHhxdrEhtOSDOtjMZQ0M6iVfCE+kWNgCkAyOdnuCWqfmflylftfadU6FkiMgHZA2kUzwRw==",
+          "requires": {
+            "asap": "~2.0.6"
+          }
+        },
+        "react-app-polyfill": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-0.2.2.tgz",
+          "integrity": "sha512-mAYn96B/nB6kWG87Ry70F4D4rsycU43VYTj3ZCbKP+SLJXwC0x6YCbwcICh3uW8/C9s1VgP197yx+w7SCWeDdQ==",
+          "requires": {
+            "core-js": "2.6.4",
+            "object-assign": "4.1.1",
+            "promise": "8.0.2",
+            "raf": "3.4.1",
+            "whatwg-fetch": "3.0.0"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1151,9 +1151,9 @@
       "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
     },
     "@mapbox/mapbox-gl-supported": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.4.0.tgz",
-      "integrity": "sha512-ZD0Io4XK+/vU/4zpANjOtdWfVszAgnaMPsGR6LKsWh4kLIEv9qoobTVmJPPuwuM+ZI2b3BlZ6DYw1XHVmv6YTA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.4.1.tgz",
+      "integrity": "sha512-yyKza9S6z3ELKuf6w5n6VNUB0Osu6Z93RXPfMHLIlNWohu3KqxewLOq4lMXseYJ92GwkRAxd207Pr/Z98cwmvw=="
     },
     "@mapbox/mapbox-sdk": {
       "version": "0.6.0",
@@ -14637,11 +14637,6 @@
       "requires": {
         "find-up": "^2.1.0"
       }
-    },
-    "platform": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
-      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q=="
     },
     "pluralize": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "moment": "^2.24.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.2",
+    "react-app-polyfill": "^1.0.2",
     "react-cookie": "^4.0.1",
     "react-date-picker": "^7.5.1",
     "react-datepicker": "^2.3.0",
@@ -58,7 +59,7 @@
   "browserslist": [
     ">0.2%",
     "not dead",
-    "not ie <= 11",
+    "not ie <= 9",
     "not op_mini all"
   ],
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@mapbox/mapbox-gl-supported": "^1.4.1",
     "@mapbox/mapbox-sdk": "^0.6.0",
     "@material-ui/core": "^3.9.2",
     "@material-ui/icons": "^3.0.2",

--- a/src/App.css
+++ b/src/App.css
@@ -243,7 +243,7 @@ List + Card
     left: 5%;
     bottom: 5%;
     width: 250px;
-    z-index: 1;
+    z-index: 1000;
     height: 60%;
     box-shadow: 2px 2px 2px;
 }

--- a/src/components/FilterDrawer.js
+++ b/src/components/FilterDrawer.js
@@ -33,7 +33,7 @@ const styles = {
         position: 'sticky',
         top: 0,
         backgroundColor: 'white',
-        zIndex: 1000,
+        zIndex: 1,
         padding: '4px 24px 4px 24px',
     },
     filterBox: {},

--- a/src/components/FilterDrawer.js
+++ b/src/components/FilterDrawer.js
@@ -33,7 +33,7 @@ const styles = {
         position: 'sticky',
         top: 0,
         backgroundColor: 'white',
-        zIndex: 1,
+        zIndex: 1000,
         padding: '4px 24px 4px 24px',
     },
     filterBox: {},

--- a/src/components/FormMap.js
+++ b/src/components/FormMap.js
@@ -1,10 +1,14 @@
 import React, { Component } from 'react';
 import ReactMapboxGl, { Layer, Feature } from 'react-mapbox-gl';
+import supported from '@mapbox/mapbox-gl-supported';
 
-const Map = ReactMapboxGl({
-  accessToken: process.env.REACT_APP_MAPBOX_TOKEN,
-  dragPan: false
-});
+let Map = null;
+if (supported({})) {
+  Map = ReactMapboxGl({
+    accessToken: process.env.REACT_APP_MAPBOX_TOKEN,
+    dragPan: false
+  });
+}
 
 class FormMap extends Component {
 
@@ -19,7 +23,7 @@ class FormMap extends Component {
     const { centerLng, centerLat } = this.props;
     return (
       <div style={{height: '100%'}}>
-        <Map style="mapbox://styles/mapbox/streets-v9"
+        {Map && <Map style="mapbox://styles/mapbox/streets-v9"
              center={{ lng: centerLng, lat: centerLat }}
              className="formMap"
         >
@@ -34,7 +38,7 @@ class FormMap extends Component {
             <Feature coordinates={[centerLng, centerLat]} draggable
                      onDragEnd={e => this.onDragEnd(e)}/>
           </Layer>
-        </Map>
+        </Map>}
       </div>
     );
   }

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -9,7 +9,7 @@ import NotFound from './NotFound';
 import ResourceCard from "./ResourceCard";
 import Resources from "./Resources";
 import SplashPage from "./SplashPage";
-
+import UnsupportedBrowserNotice from "./UnsupportedBrowserNotice";
 
 const Main = () => (
   <main className="Main">
@@ -22,7 +22,8 @@ const Main = () => (
       <Route exact path="/resources/:species" component={ResourceCard}/>
       <Route component={NotFound}/>
     </Switch>
-    <SplashPage />
+    <SplashPage/>
+    <UnsupportedBrowserNotice/>
   </main>
 );
 

--- a/src/components/MapView.js
+++ b/src/components/MapView.js
@@ -19,10 +19,16 @@ import Button from "@material-ui/core/Button";
 import AddIcon from '@material-ui/icons/Add';
 import CloseIcon from '@material-ui/icons/Close';
 import * as ReactGA from "react-ga";
+import supported from '@mapbox/mapbox-gl-supported';
 
-const Map2 = ReactMapboxGl({
-    accessToken: process.env.REACT_APP_MAPBOX_TOKEN
-});
+let Map2 = null;
+if (supported({})) {
+    Map2 = ReactMapboxGl({
+        accessToken: process.env.REACT_APP_MAPBOX_TOKEN
+    });
+}
+
+
 const getReports = "https://us-central1-seattlecarnivores-edca2.cloudfunctions.net/getReports";
 const styles = {
     filterContainer: {
@@ -248,7 +254,7 @@ class MapView extends Component {
                 { !isMobile && <div className={classes.filterContainer}>
                     <FilterDrawer/>
                 </div>}
-                <Map2 style="mapbox://styles/mapbox/streets-v9"
+                {Map2 && <Map2 style="mapbox://styles/mapbox/streets-v9"
                       className="map"
                       center={viewport.center}
                       zoom={viewport.zoom}
@@ -289,7 +295,7 @@ class MapView extends Component {
                             </div>
                         </div>
                     </div>
-                </Map2>
+                </Map2>}
             </div>
         );
     }

--- a/src/components/MapView.js
+++ b/src/components/MapView.js
@@ -37,7 +37,7 @@ const styles = {
         left: '5%',
         bottom: '5%',
         width: 250,
-        zIndex: 1,
+        zIndex: 1000,
         height: '60%',
         boxShadow: '2px 2px 2px'
     },

--- a/src/components/StaticFormMap.js
+++ b/src/components/StaticFormMap.js
@@ -1,18 +1,23 @@
 import React, { Component } from 'react';
 import ReactMapboxGl, { Layer, Feature } from 'react-mapbox-gl';
+import supported from '@mapbox/mapbox-gl-supported';
 
-const StaticMap = ReactMapboxGl({
-    accessToken: process.env.REACT_APP_MAPBOX_TOKEN,
-    dragPan: false,
-    interactive: false
-});
+
+let StaticMap = null;
+if (supported({})) {
+  StaticMap = ReactMapboxGl({
+      accessToken: process.env.REACT_APP_MAPBOX_TOKEN,
+      dragPan: false,
+      interactive: false
+  });
+}
 
 class StaticFormMap extends Component {
     render() {
         const { centerLng, centerLat} = this.props;
         return (
           <div className={"constantHeightMapContainer"}>
-            <StaticMap style="mapbox://styles/mapbox/streets-v9"
+            {StaticMap && <StaticMap style="mapbox://styles/mapbox/streets-v9"
                  center={{ lng: centerLng, lat: centerLat }}
                  className="formMap"
             >
@@ -28,7 +33,7 @@ class StaticFormMap extends Component {
                         <Feature coordinates={[centerLng, centerLat]} />
                     </Layer>
                 </div>
-            </StaticMap>
+            </StaticMap>}
           </div>
         );
     }

--- a/src/components/UnsupportedBrowserNotice.js
+++ b/src/components/UnsupportedBrowserNotice.js
@@ -1,0 +1,26 @@
+import React from "react";
+import {Dialog, DialogContent} from "@material-ui/core";
+import {withStyles} from "@material-ui/core";
+import {withCookies} from "react-cookie";
+import isSupported from "@mapbox/mapbox-gl-supported";
+
+const SEEN_UNSUPPORTED_BROWSER_BEFORE = "seenUnsupportedBrowserBefore";
+
+const styles = {
+  bulleted: {
+    listStyleType: 'disc'
+  }
+};
+
+const SplashPage = (props) => {
+  const {cookies} = props;
+  return <Dialog open={!cookies.get(SEEN_UNSUPPORTED_BROWSER_BEFORE) && !isSupported({})}
+          onClose={() => cookies.set(SEEN_UNSUPPORTED_BROWSER_BEFORE, true)}>
+    <DialogContent>
+      We've detected that you are using a browser that does not support WebGL, so the map may not render properly.
+      Please consider using a browser that supports WebGL, such as Firefox, Safari, Edge, or Chrome.
+    </DialogContent>
+  </Dialog>
+};
+
+export default withStyles(styles)(withCookies(SplashPage));

--- a/src/components/UnsupportedBrowserNotice.js
+++ b/src/components/UnsupportedBrowserNotice.js
@@ -12,7 +12,7 @@ const styles = {
   }
 };
 
-const SplashPage = (props) => {
+const UnsupportedBrowserNotice = (props) => {
   const {cookies} = props;
   return <Dialog open={!cookies.get(SEEN_UNSUPPORTED_BROWSER_BEFORE) && !isSupported({})}
           onClose={() => cookies.set(SEEN_UNSUPPORTED_BROWSER_BEFORE, true)}>
@@ -23,4 +23,4 @@ const SplashPage = (props) => {
   </Dialog>
 };
 
-export default withStyles(styles)(withCookies(SplashPage));
+export default withStyles(styles)(withCookies(UnsupportedBrowserNotice));

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import 'react-app-polyfill/ie9';
+import 'react-app-polyfill/stable';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';


### PR DESCRIPTION
This makes a couple of fixes to the app to make it (semi) compatible with Internet Explorer. 

1. Object.entries [is not supported by IE](https://caniuse.com/#search=Object.entries) but we use it a couple places. Rather than jump down the rabbit-hole of fixing individual IE-incompatible lines, I pulled in a polyfill to address the issue. 
2. Older versions of IE aren't explicitly supported by mapbox. I'm not sure whether we actually ran into any cases of this, since point 1 broke the experience for all IE users before mapbox even got involved. We now detect browsers that mapbox doesn't support, and show them a little popup--a "please use a more modern browser" type message. We also don't try to load the maps if we know they'll fail, so the users can at least see the rest of the app.
3. IE behaves weirdly with z-index and fixed-position elements, but I was able to get the filter to show up again on the list and map views by changing the containing element from z-index:1 to z-index:1000 🤷‍♂ 