### PR TITLE
API only send the information we actually display

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -100,6 +100,21 @@ buildQuery = (queryParams, collection) => {
   return initialQuery;
 };
 
+/**
+ * Reports contain a lot of extraneous (and personally identifying!) information that we should not be sending to all
+ * clients. This pulls out the important fields, which are:
+ *  - timestamp
+ *  - species
+ *  - neighborhood
+ *  - confidence
+ *  - time_submitted
+ *  - id
+ *  - mediaPaths
+ *  - mapLng
+ *  - mapLat
+ *
+ * Returns an object containing just the relevant fields from the document.
+ */
 getRelevantData = (document) => {
   const allData = document.data();
   return {

--- a/functions/index.js
+++ b/functions/index.js
@@ -60,7 +60,7 @@ exports.addReport = functions.https.onRequest((req, res) => {
  *
  * Returns an object containing just the relevant fields from the document.
  */
-getSingleDocumentRelevantData = (document) => {
+filterReport = (document) => {
   const allData = document.data();
   return {
     mediaPaths: allData.mediaPaths,
@@ -85,7 +85,7 @@ exports.getReport = functions.https.onRequest((req, res) => {
       .get()
       .then(doc => {
         if (doc.exists) {
-          return res.status(200).send(getSingleDocumentRelevantData(doc));
+          return res.status(200).send(filterReport(doc));
         } else {
           return res.status(200).send('No data!');
         }
@@ -139,7 +139,7 @@ buildQuery = (queryParams, collection) => {
  *
  * Returns an object containing just the relevant fields from the document.
  */
-getRelevantData = (document) => {
+filterReports = (document) => {
   const allData = document.data();
   return {
     timestamp: allData.timestamp,
@@ -182,13 +182,13 @@ exports.getReports = functions.https.onRequest((req, res) => {
               const distance = turf.distance(from, to, options);
               // If distance is within 500 miles from the query lat long
               if (distance <= 500) {
-                items.push({ id: doc.id, data: getRelevantData(doc) });
+                items.push({ id: doc.id, data: filterReports(doc) });
               }
             }
           });
         } else {
           snapshot.forEach(doc => {
-            items.push({ id: doc.id, data: getRelevantData(doc) });
+            items.push({ id: doc.id, data: filterReports(doc) });
           });
         }
         return items.length === 0 ? res.status(200).send('No data!') : res.status(200).send(items);

--- a/functions/index.js
+++ b/functions/index.js
@@ -100,6 +100,21 @@ buildQuery = (queryParams, collection) => {
   return initialQuery;
 };
 
+getRelevantData = (document) => {
+  const allData = document.data();
+  return {
+    timestamp: allData.timestamp,
+    species: allData.species,
+    neighborhood: allData.neighborhood,
+    confidence: allData.confidence,
+    time_submitted: allData.time_submitted,
+    id: allData.id,
+    mediaPaths: allData.mediaPaths,
+    mapLng: allData.mapLng,
+    mapLat: allData.mapLat
+  }
+};
+
 exports.getReports = functions.https.onRequest((req, res) => {
   return cors(req, res, () => {
     if (req.method !== 'GET') {
@@ -128,13 +143,13 @@ exports.getReports = functions.https.onRequest((req, res) => {
               const distance = turf.distance(from, to, options);
               // If distance is within 500 miles from the query lat long
               if (distance <= 500) {
-                items.push({ id: doc.id, data: doc.data() });
+                items.push({ id: doc.id, data: getRelevantData(doc) });
               }
             }
           });
         } else {
           snapshot.forEach(doc => {
-            items.push({ id: doc.id, data: doc.data() });
+            items.push({ id: doc.id, data: getRelevantData(doc) });
           });
         }
         return items.length === 0 ? res.status(200).send('No data!') : res.status(200).send(items);

--- a/functions/index.js
+++ b/functions/index.js
@@ -49,6 +49,30 @@ exports.addReport = functions.https.onRequest((req, res) => {
     });
   });
 });
+/**
+ * Reports contain a lot of extraneous (and personally identifying!) information that we should not be sending to all
+ * clients. This pulls out the important fields for a single report viewing, which are:
+ *  - timestamp
+ *  - species
+ *  - neighborhood
+ *  - confidence
+ *  - mediaPaths
+ *
+ * Returns an object containing just the relevant fields from the document.
+ */
+getSingleDocumentRelevantData = (document) => {
+  const allData = document.data();
+  return {
+    mediaPaths: allData.mediaPaths,
+    species: allData.species,
+    timestamp: allData.timestamp,
+    neighborhood: allData.neighborhood,
+    confidence: allData.confidence,
+    numberOfAdultSpecies: allData.numberOfAdultSpecies,
+    numberOfYoungSpecies: allData.numberOfYoungSpecies
+  }
+};
+
 
 exports.getReport = functions.https.onRequest((req, res) => {
   return cors(req, res, () => {
@@ -61,7 +85,7 @@ exports.getReport = functions.https.onRequest((req, res) => {
       .get()
       .then(doc => {
         if (doc.exists) {
-          return res.status(200).send(doc.data());
+          return res.status(200).send(getSingleDocumentRelevantData(doc));
         } else {
           return res.status(200).send('No data!');
         }


### PR DESCRIPTION
### Current State
Users sometimes enter personal information (including contact info and names) in their report submissions. We don't display this information anywhere on the app, yet our `getReports` endpoint includes that information in its response:

[{"id":"TxK9BVEWzCobjM2LwghV","data":{"generalComments":"First sighting of this adult coyote in our yard. Has been in and out for the past week. ","neighborhood":"Unknown","animalFeatures":"",**"contactEmail":"REDACTED@REDACTED"**,"mapLng":-122.306567,**"contactPhone":"REDACTED"**,"conflictDesc":"","reaction":"",**"contactName":"REDACTED"**,"carnivoreConflict":"","vocalizationDesc":"","numberOfDogs":"","vocalization":"","carnivoreResponse":"","numberOfYoungSpecies":"0","animalEating":"","timestamp":"2019-08-23T00:30:00.000Z","mapLat":47.700826,"animalBehavior":"Other","time_submitted":{"_seconds":1566689550,"_nanoseconds":307000000},"reactionDescription":"","species":"Coyote","onLeash":"","numberOfAdults":"","numberOfChildren":"","confidence":"100% confident","mediaPaths":[],"dogSize":"","numberOfAdultSpecies":"1"}},...]

### Updates
I went through and found all the fields that we're actually using, and updated getReports to only send those fields. This should save us some bandwidth and also improve privacy/security.

[{"id":"KeweYzQOdwn2PoXxdiiN","data":{"timestamp":"2019-07-20T06:15:00.000Z","species":"Raccoon","neighborhood":"Ravenna","confidence":"100% confident","time_submitted":{"_seconds":1562513761,"_nanoseconds":0},"mediaPaths":["https://firebasestorage.googleapis.com/v0/b/seattlecarnivores-edca2.appspot.com/o/images%2F3285653a-2263-432a-b115-ab85f17cbd03.JPG?alt=media&token=6bcdb17e-da66-4d7f-99f5-1b185659a171"],"mapLng":-122.30560337839486,"mapLat":47.67173162294344}},...]

(I know these are two distinct documents -- the fields across all documents are the same, so we can see here that the PII fields like contactEmail etc are not present in the new payload)

### Testing approach
I tested this by spinning up a local version of firebase functions (`firebase serve --only functions`). Then I updated `getReports` to point to my local instance in `MapView` and `ListView`. From there I was able to run the app locally, using my local firebase functions instance. Clicking around and navigating to individual reports appeared to work (with images loading properly as well) from both MapView and ListView. 