### PR TITLE
Update Node Version

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -370,7 +370,7 @@ const sendNewSubmissionEmail = (reportSnapshot) => {
 };
 
 const sendWeeklyDigestEmail = (reportSnapshots) => {
-  const from = `"Test reporters" <${username}@example.com>`;
+  const from = `"Test reporters" <${username}@gmail.com>`;
   const to = `"Seattle Carnivore Spotter" <seattlecarnivores@zoo.org>`;
   const subject = "Weekly Carnivore Spotting Submission Digest";
   const styles = `<style>

--- a/functions/index.js
+++ b/functions/index.js
@@ -408,7 +408,6 @@ exports.sendEmailOnReportTacomaCreation = functions.firestore.document(`${REPORT
       sendNewSubmissionEmail(snapshot);
     });
 
-
 /**
  * Every week, send a digest containing all of the submissions from the last week.
  */

--- a/functions/index.js
+++ b/functions/index.js
@@ -12,8 +12,8 @@ const NEIGHBORHOOD = 'neighborhood';
 const UNIQUES = 'uniques';
 const REPORTS = 'reports';
 const REPORTS_TACOMA = 'reportsTacoma';
-const REPORT_URL_STUB = 'https://console.firebase.google.com/project/seattlecarnivores-edca2/database/firestore/data~2Freports';
-const TACOMA_REPORTS_URL = 'https://console.firebase.google.com/project/seattlecarnivores-edca2/database/firestore/data~2FreportsTacoma';
+const REPORT_URL_STUB = 'https://console.firebase.google.com/project/seattlecarnivores-edca2/database/firestore/data~2Freports~2F';
+const TACOMA_REPORTS_URL = 'https://console.firebase.google.com/project/seattlecarnivores-edca2/database/firestore/data~2FreportsTacoma~2F';
 
 // initialize username/password
 const username = functions.config().email.username;
@@ -350,7 +350,7 @@ const formatSubmissionAsTable = (reportSnapshots) => {
 };
 
 const sendNewSubmissionEmail = (reportSnapshot) => {
-    const from = `"Test reporters" <${username}@example.com>`;
+    const from = `"Test reporters" <${username}@gmail.com>`;
     const to = `"Seattle Carnivore Spotter" <seattlecarnivores@zoo.org>`;
     const subject = "New report submitted";
     const styles = `<style>
@@ -370,7 +370,7 @@ const sendNewSubmissionEmail = (reportSnapshot) => {
 };
 
 const sendWeeklyDigestEmail = (reportSnapshots) => {
-  const from = `"Test reporters" <${username}@example.com>`;
+  const from = `"Test reporters" <${username}@gmail.com>`;
   const to = `"Seattle Carnivore Spotter" <seattlecarnivores@zoo.org>`;
   const subject = "Weekly Carnivore Spotting Submission Digest";
   const styles = `<style>
@@ -407,6 +407,23 @@ exports.reportAdded = functions.firestore.document(`${REPORTS_TACOMA}/{reportId}
     .onCreate((snapshot, context) => {
       sendNewSubmissionEmail(snapshot);
     });
+
+/**
+ * Whenever a new document is added to the reports collection, send a notification email.
+ */
+exports.sendEmailOnReportCreation = functions.firestore.document(`${REPORTS}/{reportId}`)
+    .onCreate((snapshot, context) => {
+      sendNewSubmissionEmail(snapshot);
+    });
+
+/**
+ * Whenever a new document is added to the Tacoma reports collection, send a notification email.
+ */
+exports.sendEmailOnReportTacomaCreation = functions.firestore.document(`${REPORTS_TACOMA}/{reportId}`)
+    .onCreate((snapshot, context) => {
+      sendNewSubmissionEmail(snapshot);
+    });
+
 
 /**
  * Every week, send a digest containing all of the submissions from the last week.

--- a/functions/index.js
+++ b/functions/index.js
@@ -370,7 +370,7 @@ const sendNewSubmissionEmail = (reportSnapshot) => {
 };
 
 const sendWeeklyDigestEmail = (reportSnapshots) => {
-  const from = `"Test reporters" <${username}@gmail.com>`;
+  const from = `"Test reporters" <${username}@example.com>`;
   const to = `"Seattle Carnivore Spotter" <seattlecarnivores@zoo.org>`;
   const subject = "Weekly Carnivore Spotting Submission Digest";
   const styles = `<style>
@@ -391,22 +391,6 @@ const sendWeeklyDigestEmail = (reportSnapshots) => {
       ${formatSubmissionAsTable(reportSnapshots)}`;
   return sendEmail(from, to, subject, html);
 };
-
-/**
- * Whenever a new document is added to the reports collection, send a notification email.
- */
-exports.reportAdded = functions.firestore.document(`${REPORTS}/{reportId}`)
-    .onCreate((snapshot, context) => {
-      sendNewSubmissionEmail(snapshot);
-    });
-
-/**
- * Whenever a new document is added to the Tacoma reports collection, send a notification email.
- */
-exports.reportAdded = functions.firestore.document(`${REPORTS_TACOMA}/{reportId}`)
-    .onCreate((snapshot, context) => {
-      sendNewSubmissionEmail(snapshot);
-    });
 
 /**
  * Whenever a new document is added to the reports collection, send a notification email.

--- a/functions/package.json
+++ b/functions/package.json
@@ -26,6 +26,6 @@
   },
   "private": true,
   "engines": {
-    "node": "8"
+    "node": "10"
   }
 }


### PR DESCRIPTION
Node.js 8 has been deprecated as of June 8 2020 and Firebase does not support Node.js 8 functions to be executed starting Feb 2021. This Pr updates the node version to 10. It also includes renaming couple of firebase functions for readability.